### PR TITLE
simple build fails without correct plugin repositories listed 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
     <build>
         <plugins>
             <!-- TODO replace with java.level=6 once we have a better plugin parent POM: -->
@@ -201,4 +195,18 @@
             </build>
         </profile>
     </profiles>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>


### PR DESCRIPTION

(mvn -DskipTests clean install)
without this fix the build fails with this error:
[ERROR]     Unresolveable build extension: Plugin org.jenkins-ci.tools:maven-hpi-plugin:1.110 or one of its dependencies could not be resolved: Could not find artifact org.jenkins-ci.tools:maven-hpi-plugin:jar:1.110 in central (http://repo.maven.apache.org/maven2) -> [Help 2]
[ERROR] 
