### PR TITLE
Skip unit tests when required tooling (hg, svn) is not installed.

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SubversionStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SubversionStepTest.java
@@ -64,8 +64,12 @@ public class SubversionStepTest {
         } catch (NoSuchMethodException x) {
             // prior to Java 7
         }
-        int r = pb.directory(cwd).start().waitFor();
-        Assume.assumeTrue(Arrays.toString(cmds) + " failed with error code " + r, r == 0);
+        try {
+            int r = pb.directory(cwd).start().waitFor();
+            Assume.assumeTrue(Arrays.toString(cmds) + " failed with error code " + r, r == 0);
+        } catch (Exception ex) {
+            Assume.assumeNoException(Arrays.toString(cmds) + " failed with exception (required tooling not installed?)", ex);
+        }
     }
 
     private static String uuid(String url) throws Exception {


### PR DESCRIPTION
If the SCM tools are not installed (subversion/mercurial) then don't fail the unit tests.

@reviewbybees