### PR TITLE
[JENKINS-26121] Approver Logged

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2014, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package org.jenkinsci.plugins.workflow.steps.input;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -5,6 +29,7 @@ import hudson.model.BooleanParameterDefinition;
 import hudson.model.Job;
 import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;
+
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,6 +42,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.input.ApproverAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
@@ -24,6 +50,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -37,11 +65,15 @@ public class InputStepTest extends Assert {
      */
     @Test
     public void parameter() throws Exception {
+
+
+        //set up dummy security real
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         // job setup
         WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
         foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList(
                 "echo('before');",
-                "def x = input message:'Do you want chocolate?', id:'Icecream', ok: 'Purchase icecream', parameters: [[$class: 'BooleanParameterDefinition', name: 'chocolate', defaultValue: false, description: 'Favorite icecream flavor']];",
+                "def x = input message:'Do you want chocolate?', id:'Icecream', ok: 'Purchase icecream', parameters: [[$class: 'BooleanParameterDefinition', name: 'chocolate', defaultValue: false, description: 'Favorite icecream flavor']], submitter:'alice';",
                 "echo(\"after: ${x}\");"),"\n"),true));
 
 
@@ -61,11 +93,14 @@ public class InputStepTest extends Assert {
         InputStepExecution is = a.getExecution("Icecream");
         assertEquals("Do you want chocolate?", is.getInput().getMessage());
         assertEquals(1, is.getInput().getParameters().size());
+        assertEquals("alice", is.getInput().getSubmitter());
 
         j.assertEqualDataBoundBeans(is.getInput().getParameters().get(0), new BooleanParameterDefinition("chocolate", false, "Favorite icecream flavor"));
 
         // submit the input, and run workflow to the completion
-        HtmlPage p = j.createWebClient().getPage(b, a.getUrlName());
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("alice");
+        HtmlPage p = wc.getPage(b, a.getUrlName());
         j.submit(p.getFormByName(is.getId()),"proceed");
         assertEquals(0, a.getExecutions().size());
         q.get();
@@ -73,6 +108,11 @@ public class InputStepTest extends Assert {
         // make sure 'x' gets assigned to false
         System.out.println(b.getLog());
         assertTrue(b.getLog().contains("after: false"));
+
+        //make sure the approver name corresponds to the submitter
+        ApproverAction action = b.getAction(ApproverAction.class);
+        assertNotNull(action);
+        assertEquals(is.getInput().getSubmitter(), action.getUserId());
     }
 
     @Test

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.steps.input;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.Job;
@@ -101,9 +103,21 @@ public class InputStepTest extends Assert {
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.login("alice");
         HtmlPage p = wc.getPage(b, a.getUrlName());
-        j.submit(p.getFormByName(is.getId()),"proceed");
+        j.submit(p.getFormByName(is.getId()), "proceed");
         assertEquals(0, a.getExecutions().size());
         q.get();
+
+        // make sure the valid hyperlink of the approver is created in the build index page
+        HtmlAnchor pu =null;
+
+        try {
+            pu = p.getAnchorByText("alice");
+        }
+        catch(ElementNotFoundException ex){
+            System.out.println("valid hyperlink of the approved does not appears on the build index page");
+        }
+
+        assertNotNull(pu);
 
         // make sure 'x' gets assigned to false
         System.out.println(b.getLog());
@@ -112,7 +126,7 @@ public class InputStepTest extends Assert {
         //make sure the approver name corresponds to the submitter
         ApproverAction action = b.getAction(ApproverAction.class);
         assertNotNull(action);
-        assertEquals(is.getInput().getSubmitter(), action.getUserId());
+        assertEquals("alice", action.getUserId());;
     }
 
     @Test

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
@@ -26,8 +26,12 @@ package org.jenkinsci.plugins.workflow.support.steps.input;
 
 import hudson.model.InvisibleAction;
 import hudson.model.User;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author Valentina Armenise
@@ -38,20 +42,19 @@ public class ApproverAction extends InvisibleAction {
 
     public ApproverAction(String userId) {
         this.userId = userId;
-        this.username=User.get(userId).getDisplayName();
     }
 
+    @Nonnull
     final private String userId;
-    final private String username;
 
-    @Exported
+    @Restricted(DoNotUse.class)
     public String getUserId() {
         return userId;
     }
 
-    @Exported
+    @Restricted(DoNotUse.class)
     public String getUserName() {
-        return userId == null ? "anonymous" : username;
+        return User.get(userId).getDisplayName();
     }
 
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
@@ -47,7 +47,7 @@ public class ApproverAction extends InvisibleAction {
     @Nonnull
     final private String userId;
 
-    @Restricted(DoNotUse.class)
+    @Exported
     public String getUserId() {
         return userId;
     }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2014, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps.input;
+
+import hudson.model.InvisibleAction;
+import hudson.model.User;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * @author Valentina Armenise
+ */
+
+@ExportedBean
+public class ApproverAction extends InvisibleAction {
+
+    public ApproverAction(String userId) {
+        this.userId = userId;
+        this.username=User.get(userId).getDisplayName();
+    }
+
+    final private String userId;
+    final private String username;
+
+    @Exported
+    public String getUserId() {
+        return userId;
+    }
+
+    @Exported
+    public String getUserName() {
+        return userId == null ? "anonymous" : username;
+    }
+
+
+}

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -141,7 +141,11 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     @RequirePOST
     public HttpResponse doProceed(StaplerRequest request) throws IOException, ServletException, InterruptedException {
         preSubmissionCheck();
-
+        User user = User.current();
+        if (user!=null){
+            run.addAction(new ApproverAction(user.getId()));
+            listener.getLogger().println("Approved by " + hudson.console.ModelHyperlinkNote.encodeTo(user));
+        }
         Object v = parseValue(request);
         return proceed(v);
     }

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction/summary.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction/summary.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright (c) 2013-2014, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+ <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+   <t:summary icon="orange-square.png">
+        ${%approved_by_user(it.userId, it.userName, rootURL)}.
+   </t:summary>
+ </j:jelly>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction/summary.properties
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/ApproverAction/summary.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2013-2014, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+approved_by_user=This was approved by user <a href="{2}/user/{0}">{1}</a>


### PR DESCRIPTION
This solves https://issues.jenkins-ci.org/browse/JENKINS-26121.

The input step now records and shows who approved the request.

However, if you are NOT logged in and try to approve, you are prompted with the error message which says "you need to be X to submit".
if you log in, then you are asked to "try POST" and if you click POST an empty request(request has not parameters) is SENT causing the doSubmit to abort  the input step (even if you have approved instead).

   @RequirePOST
    public HttpResponse doSubmit(StaplerRequest request) throws IOException, ServletException, InterruptedException {
        if (request.getParameter("proceed")!=null) {
            User user= User.current();
            doProceed(request, user);
        } else {
            doAbort();
        }

        // go back to the Run console page
        return HttpResponses.redirectTo("../../console");
    }

This behaviour is detected in the master as well and should be fixed.
