### PR TITLE
Memory leaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ### User changes
 * Ability to configure project display name.
 * Fixing `java.io.NotSerializableException: org.jenkinsci.plugins.workflow.support.steps.StageStepExecution$CanceledCause` thrown from certain scripts using `stage`.
+* PR 52: fixed some memory leaks causing the permanent generation and heap to grow unbounded after many flow builds.
 
 ## 1.2 (Jan 24 2015)
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/CpsFlowExecutionTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/CpsFlowExecutionTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import org.codehaus.groovy.transform.ASTTransformationVisitor;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MemoryAssert;
+
+public class CpsFlowExecutionTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
+    private static WeakReference<ClassLoader> LOADER;
+    public static void register(Object o) {
+        LOADER = new WeakReference<ClassLoader>(o.getClass().getClassLoader());
+    }
+    @Test public void loaderReleased() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionTest.class.getName() + ".register(this)"));
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertNotNull(LOADER);
+        System.err.println(LOADER.get());
+        {
+            // TODO in Groovy 1.8.9 this keeps static state, but only for the last script (as also noted in JENKINS-23762).
+            // The fix of GROOVY-5025 (62bfb68) in 1.9 addresses this, which we would get if JENKINS-21249 is implemented.
+            Field f = ASTTransformationVisitor.class.getDeclaredField("compUnit");
+            f.setAccessible(true);
+            f.set(null, null);
+        }
+        MemoryAssert.assertGC(LOADER);
+    }
+
+    /* Failed attempt to make the test print soft references it has trouble clearing. The test ultimately passes, but cannot find the soft references via any root path.
+    private static void assertGC(WeakReference<?> reference) throws Exception {
+        assertTrue(true); reference.get(); // preload any needed classes!
+        Set<Object[]> objects = new HashSet<Object[]>();
+        int size = 1024;
+        while (reference.get() != null) {
+            LiveEngine e = new LiveEngine();
+            // The default filter, ScannerUtils.skipNonStrongReferencesFilter(), omits SoftReference.referent that we care about.
+            // The constructor accepting a filter ANDs it with the default filter, making it useless for this purpose.
+            Field f = LiveEngine.class.getDeclaredField("filter");
+            f.setAccessible(true);
+            f.set(e, new Filter() {
+                final Field referent = Reference.class.getDeclaredField("referent");
+                @Override public boolean accept(Object obj, Object referredFrom, Field reference) {
+                    return !(referent.equals(reference) && referredFrom instanceof WeakReference);
+                }
+            });
+            System.err.println(e.trace(Collections.singleton(reference.get()), null));
+            System.err.println("allocating " + size);
+            try {
+                objects.add(new Object[size]);
+            } catch (OutOfMemoryError ignore) {
+                break;
+            }
+            size *= 1.1;
+            System.gc();
+        }
+        objects = null;
+        System.gc();
+        Object obj = reference.get();
+        if (obj != null) {
+            fail(LiveReferences.fromRoots(Collections.singleton(obj)).toString());
+        }
+    }
+    */
+
+}

--- a/cps/pom.xml
+++ b/cps/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.cloudbees</groupId>
             <artifactId>groovy-cps</artifactId>
-            <version>1.2-SNAPSHOT</version> <!-- TODO memory-leak branch -->
+            <version>1.2</version>
         </dependency>
     </dependencies>
     <!-- TODO currently job depends on tests from here; this dependency should probably be broken -->

--- a/cps/pom.xml
+++ b/cps/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.cloudbees</groupId>
             <artifactId>groovy-cps</artifactId>
-            <version>1.1</version>
+            <version>1.2-SNAPSHOT</version> <!-- TODO memory-leak branch -->
         </dependency>
     </dependencies>
     <!-- TODO currently job depends on tests from here; this dependency should probably be broken -->


### PR DESCRIPTION
When running a flow repeatedly, the `WorkflowScript` (a dynamic `CpsScript` subclass) is not promptly collected, nor is its `GroovyClassLoader.InnerLoader` and thus an assortment of derivative classes and objects. Demo:

```bash
jmap -histo $pid | fgrep WorkflowScript | wc -l
```

prints the number of builds you have just run. (Note that each line is a class called `WorkflowScript` from its own class loader.)

I think I have fixed all the hard-reference leaks, so Jenkins will collect the remaining `SoftReference`s under heavy memory pressure rather than throwing an `OutOfMemoryError`; to demo, using the current patch run in `/script`

```groovy
for (i = 1; ; i *= 2) {
  System.gc();
  new Object[i];
}
```

and the `WorkflowScript` count will drop to 0. Sometimes this also happens after merely

```groovy
System.gc();
```

But in the meantime the heap (or in Java 6/7, permanent generation) slowly grows.

@reviewbybees (ref. ZD-24759)

- [X] reproduce hard leaks in functional test
- [X] fix `CpsFlowExecution.shell` leak
- [X] fix `Caller.Info` leak
- [x] for above leak, integrate https://github.com/cloudbees/groovy-cps/pull/2 once merged and released
- [X] fix `SerializableClassRegistry` leak (arguably a bug in JBoss Marshalling, though [JDK-6389107](https://bugs.openjdk.java.net/browse/JDK-6389107) makes it hard to fix)
- [X] fix `java.beans.Introspector` leak (also related to JDK-6389107)
- [ ] fix `org.codehaus.groovy.reflection.ClassInfo$ClassInfoSet$Segment.table` leak, or hope that https://github.com/groovy/groovy-core/commit/97d78e9 in 2.4.0-beta-2 solves this (cf. https://github.com/jenkinsci/jenkins/pull/1085)
- [x] changelog