### PR TITLE
Random test failure

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
@@ -358,7 +358,7 @@ public class ParallelStepTest extends SingleJobTestBase {
                 assertEquals("Expecting 3 heads for 3 branches", 3,e.getCurrentHeads().size());
 
                 a.getExecutions().get(0).proceed(null);
-                waitForWorkflowToSuspend();
+                waitForWorkflowToComplete();
 
                 story.j.assertBuildStatus(Result.FAILURE, b);
 


### PR DESCRIPTION
Observed once to fail saying that the build status was `null` rather than `FAILURE`, perhaps because the flow had suspended and was just about to complete but had not done so yet.

@reviewbybees