### PR TITLE
Handle FlowInterruptedException from CatchErrorStep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ### User changes
 * Ability to configure project display name.
 * Fixing `java.io.NotSerializableException: org.jenkinsci.plugins.workflow.support.steps.StageStepExecution$CanceledCause` thrown from certain scripts using `stage`.
+* `catchError` was incorrectly setting build status to failed when it was merely aborted, canceled, etc.
 
 ## 1.2 (Jan 24 2015)
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import jenkins.model.CauseOfInterruption;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CatchErrorStepTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void specialStatus() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "catchError {\n" +
+                "  semaphore 'specialStatus'\n" +
+                "}"));
+        SemaphoreStep.failure("specialStatus/1", new FlowInterruptedException(Result.UNSTABLE, new CauseOfInterruption.UserInterruption("smrt")));
+        WorkflowRun b = p.scheduleBuild2(0).get();
+        r.assertLogContains("smrt", r.assertBuildStatus(Result.UNSTABLE, b));
+        /* TODO fixing this is trickier since CpsFlowExecution.setResult does not implement a public method, and anyway CatchErrorStep in its current location could not refer to FlowExecution:
+        List<FlowNode> heads = b.getExecution().getCurrentHeads();
+        assertEquals(1, heads.size());
+        assertEquals(Result.UNSTABLE, ((FlowEndNode) heads.get(0)).getResult());
+        */
+    }
+
+}

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -87,12 +87,17 @@ public final class CatchErrorStep extends AbstractStepImpl {
             @Override public void onFailure(StepContext context, Throwable t) {
                 try {
                     TaskListener listener = context.get(TaskListener.class);
+                    Result r = Result.FAILURE;
                     if (t instanceof AbortException) {
                         listener.error(t.getMessage());
+                    } else if (t instanceof FlowInterruptedException) {
+                        FlowInterruptedException fie = (FlowInterruptedException) t;
+                        fie.handle(context.get(Run.class), listener);
+                        r = fie.getResult();
                     } else {
                         t.printStackTrace(listener.getLogger());
                     }
-                    context.get(Run.class).setResult(Result.FAILURE);
+                    context.get(Run.class).setResult(r);
                     context.onSuccess(null);
                 } catch (Exception x) {
                     context.onFailure(x);

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -66,8 +66,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-import jenkins.model.CauseOfInterruption;
-import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
 import jenkins.model.lazy.BuildReference;
 import jenkins.model.lazy.LazyBuildMixIn;
@@ -334,11 +332,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
         if (t instanceof AbortException) {
             listener.error(t.getMessage());
         } else if (t instanceof FlowInterruptedException) {
-            List<CauseOfInterruption> causes = ((FlowInterruptedException) t).getCauses();
-            addAction(new InterruptedBuildAction(causes));
-            for (CauseOfInterruption cause : causes) {
-                cause.print(listener);
-            }
+            ((FlowInterruptedException) t).handle(this, listener);
         } else if (t != null) {
             t.printStackTrace(listener.getLogger());
         }

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -26,6 +26,8 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.model.Executor;
 import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import jenkins.model.CauseOfInterruption;
+import jenkins.model.InterruptedBuildAction;
 
 /**
  * Special exception that can be thrown out of {@link StepContext#onFailure} to indicate that the flow was aborted from the inside.
@@ -80,6 +83,18 @@ public final class FlowInterruptedException extends InterruptedException {
 
     public @Nonnull List<CauseOfInterruption> getCauses() {
         return allCauses;
+    }
+
+    /**
+     * If a build catches this exception, it should use this method to report it.
+     * @param run
+     * @param listener
+     */
+    public void handle(Run<?,?> run, TaskListener listener) {
+        run.addAction(new InterruptedBuildAction(allCauses));
+        for (CauseOfInterruption cause : allCauses) {
+            cause.print(listener);
+        }
     }
 
 }


### PR DESCRIPTION
Previously was marking a build as failed when it was merely supposed to be canceled due to a superseded stage, etc.

@reviewbybees (ref. ZD-24677)