### PR TITLE
[JENKINS-26605] LogActionImpl was missing a definition of skipSome

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ### User changes
 * Ability to configure project display name.
 * Fixing `java.io.NotSerializableException: org.jenkinsci.plugins.workflow.support.steps.StageStepExecution$CanceledCause` thrown from certain scripts using `stage`.
+* JENKINS-26605: Missing link to _Full Log_ under _Running Steps_ when a single step produced >150Kb of output.
 
 ## 1.2 (Jan 24 2015)
 

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.jelly
@@ -38,10 +38,10 @@ THE SOFTWARE.
 
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
-      <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />
+      <j:set var="offset" value="${request.hasParameter('consoleFull') ? 0 : it.logText.length()-threshold*1024}" />
       <j:choose>
         <j:when test="${offset > 0}">
-          ${%skipSome(offset/1024,"consoleFull")}
+          ${%skipSome(offset/1024,"?consoleFull")}
         </j:when>
         <j:otherwise>
           <j:set var="offset" value="${0}" />

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.properties
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.properties
@@ -1,0 +1,2 @@
+skipSome=Skipping {0,number,integer} KB.. <a href="{1}">Full Log</a>
+


### PR DESCRIPTION
[JENKINS-26605](https://issues.jenkins-ci.org/browse/JENKINS-26605)

@reviewbybees