### PR TITLE
[JENKINS-26619] DescribableHelper does not handle GitSCMExtension

### DIFF
--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
@@ -200,7 +200,9 @@ public class DescribableHelper {
 
     @SuppressWarnings("unchecked")
     private static boolean isList(Type type) {
-        return type instanceof ParameterizedType && ((ParameterizedType) type).getRawType() instanceof Class && ((Class) ((ParameterizedType) type).getRawType()).isAssignableFrom(List.class);
+        return type instanceof ParameterizedType
+                && ((ParameterizedType) type).getRawType() instanceof Class
+                && List.class.isAssignableFrom((Class) ((ParameterizedType) type).getRawType());
     }
 
     private static List<Object> mapList(String context, Type type, List<?> list) throws Exception {


### PR DESCRIPTION
[JENKINS-26619](https://issues.jenkins-ci.org/browse/JENKINS-26619)

@reviewByBees this also cover #685