### PR TITLE
[JENKINS-25890] Deadlock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.3 (upcoming)
 
 ### User changes
+* JENKINS-25890: deadlock during restart.
 * Fixed some file handle leaks caught by tests which may have affected Windows masters.
 * JENKINS-25779: snippet generator now omits default values of complex steps.
 * Ability to configure project display name.

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -650,7 +650,6 @@ public class WorkflowTest extends SingleJobTestBase {
         });
     }
 
-    @RandomlyFails("TODO JENKINS-25890 sometimes triggers a deadlock after restart")
     @Issue("JENKINS-26513")
     @Test public void executorStepRestart() {
         story.addStep(new Statement() {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodySubContext.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodySubContext.java
@@ -74,7 +74,7 @@ final class CpsBodySubContext extends DefaultStepContext {
     }
 
     @Override
-    public boolean isReady() throws IOException, InterruptedException {
+    public boolean isReady() {
         return base.isReady();
     }
 

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/StepContext.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/StepContext.java
@@ -83,7 +83,7 @@ public abstract class StepContext implements FutureCallback<Object>, Serializabl
      * May be called to break deadlocks during reloading.
      * @return true normally, false if we are still reloading the context, for example during unpickling
      */
-    public abstract boolean isReady() throws IOException, InterruptedException;
+    public abstract boolean isReady();
 
     /**
      * Requests that any state held by the {@link StepExecution} be saved to disk.


### PR DESCRIPTION
[JENKINS-25890](https://issues.jenkins-ci.org/browse/JENKINS-25890)

Reproduced by a revision of the test added in #62.

Removing the exceptions from the declaration of `isReady` to emphasize that it is not intended to block.

@reviewbybees esp. @kohsuke