### PR TITLE
[JENKINS-25890] Use own thread pool for CpsStepContext.getProgramPromise

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -427,6 +427,7 @@ public class CpsFlowExecution extends FlowExecution {
                         }
 
                         public void onFailure(Throwable t) {
+                            // Note: not calling result.setException(t) since loadProgramFailed in fact sets a result
                             try {
                                 loadProgramFailed(t, result);
                             } finally {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.ContextResettingExecutorService;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
@@ -228,7 +229,7 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
         }
     }
 
-    private static final ExecutorService getProgramPromiseExecutorService = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "CpsStepContext.getProgramPromise"));
+    private static final ExecutorService getProgramPromiseExecutorService = new ContextResettingExecutorService(Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "CpsStepContext.getProgramPromise")));
     private @Nonnull ListenableFuture<CpsThreadGroup> getProgramPromise() {
         final SettableFuture<CpsThreadGroup> f = SettableFuture.create();
         // TODO is there some more convenient way of writing this using Futures.transform? FlowExecutionOwner.get should really return ListenableFuture<FlowExecution>

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -31,6 +31,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import groovy.lang.Closure;
 import hudson.model.Descriptor;
 import hudson.model.Result;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
@@ -57,9 +59,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.util.Timer;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
@@ -224,11 +227,12 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
             throw new IOException(e);
         }
     }
-    
+
+    private static final ExecutorService getProgramPromiseExecutorService = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "CpsStepContext.getProgramPromise"));
     private @Nonnull ListenableFuture<CpsThreadGroup> getProgramPromise() {
         final SettableFuture<CpsThreadGroup> f = SettableFuture.create();
-        // TODO is there some more convenient way of writing this using Futures.transform?
-        Timer.get().submit(new Runnable() {
+        // TODO is there some more convenient way of writing this using Futures.transform? FlowExecutionOwner.get should really return ListenableFuture<FlowExecution>
+        getProgramPromiseExecutorService.submit(new Runnable() {
             @Override public void run() {
                 try {
                     ListenableFuture<CpsThreadGroup> pp = getFlowExecution().programPromise;


### PR DESCRIPTION
[JENKINS-25890](https://issues.jenkins-ci.org/browse/JENKINS-25890)

Amends fix in #65. That turned out to cause `WorkflowTest.acquireWorkspace` to fail mostly reliably—it was already `@RandomlyFails`—one reason why a PR from @jtnord to use the “flaky test” feature of Surefire would be appreciated.

The problem was that rehydration of pickles via `TryRepeatedly` depends on `jenkins.util.Timer`, which is a cached thread pool with 10 threads, yet the original fix added a task to this same pool for a couple of commonly used `CpsStepContext` methods. These tasks would block waiting for the program to load, which cannot happen until all the pickles are rehydrated. Of the twelve pickles loaded in this test (six per loaded build), ten got rehydrated fine, but the last two were `ExecutorPickle`s, which are slow to rehydrate (need to wait for slaves to come online and the queue to be `maintain`ed). The first try failed due to offline slaves; `tryLater` was called, but the task was not scheduled because at that point all ten `Timer` threads were busy. Thus a deadlock, possibly reproducible only when multiple builds were being loaded.

Use of `Timer` from `TryRepeatedly` seems acceptable in general since each “try” is intended to be nonblocking. It was the new use from `CpsStepContext.getProgramPromise` that introduced the problem. Using `Executors.newCachedThreadPool` seems more appropriate here, at least until some future refactoring allows `WorkflowRun.Owner` to produce a proper `ListenableFuture<FlowExecution>` so that we can operate on callbacks rather than blocking a bunch of threads during startup.

@reviewbybees esp. @kohsuke