### PR TITLE
[FIXED JENKINS-26363] Input step should permit cancellation from anyone with Job.CANCEL permission

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
@@ -2,8 +2,16 @@ package org.jenkinsci.plugins.workflow.steps.input;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.BooleanParameterDefinition;
+import hudson.model.Job;
+import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;
+
 import java.util.Arrays;
+import java.util.List;
+
+import hudson.security.ACL;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -14,6 +22,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -64,5 +73,78 @@ public class InputStepTest extends Assert {
         // make sure 'x' gets assigned to false
         System.out.println(b.getLog());
         assertTrue(b.getLog().contains("after: false"));
+    }
+
+    @Test
+    @Issue("JENKINS-26363")
+    public void test_cancel_run_by_input() throws Exception {
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        JenkinsRule.DummySecurityRealm dummySecurityRealm = j.createDummySecurityRealm();
+        GlobalMatrixAuthorizationStrategy authorizationStrategy = new GlobalMatrixAuthorizationStrategy();
+
+        j.jenkins.setSecurityRealm(dummySecurityRealm);
+
+        // Only give "alice" basic privs. That's normally not enough to Job.CANCEL, only for the fact that "alice"
+        // is listed as the submitter.
+        addUserWithPrivs("alice", authorizationStrategy);
+        // Only give "bob" basic privs.  That's normally not enough to Job.CANCEL and "bob" is not the submitter,
+        // so they should be rejected.
+        addUserWithPrivs("bob", authorizationStrategy);
+        // Give "charlie" basic privs + Job.CANCEL.  That should allow user3 cancel.
+        addUserWithPrivs("charlie", authorizationStrategy);
+        authorizationStrategy.add(Job.CANCEL, "charlie");
+
+        j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+
+        final WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
+        ACL.impersonate(User.get("alice").impersonate(), new Runnable() {
+            @Override
+            public void run() {
+                foo.setDefinition(new CpsFlowDefinition("input id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'alice'"));
+            }
+        });
+
+        runAndAbort(webClient, foo, "alice", true);   // alice should work coz she's declared as 'submitter'
+        runAndAbort(webClient, foo, "bob", false);    // bob shouldn't work coz he's not declared as 'submitter' and doesn't have Job.CANCEL privs
+        runAndAbort(webClient, foo, "charlie", true); // charlie should work coz he has Job.CANCEL privs
+    }
+
+    private void runAndAbort(JenkinsRule.WebClient webClient, WorkflowJob foo, String loginAs, boolean expectAbortOk) throws Exception {
+        // get the build going, and wait until workflow pauses
+        QueueTaskFuture<WorkflowRun> queueTaskFuture = foo.scheduleBuild2(0);
+        WorkflowRun run = queueTaskFuture.getStartCondition().get();
+        CpsFlowExecution execution = (CpsFlowExecution) run.getExecutionPromise().get();
+
+        while (run.getAction(InputAction.class) == null) {
+            execution.waitForSuspension();
+        }
+
+        webClient.login(loginAs);
+
+        InputAction inputAction = run.getAction(InputAction.class);
+        InputStepExecution is = inputAction.getExecution("InputX");
+        HtmlPage p = webClient.getPage(run, inputAction.getUrlName());
+
+        try {
+            j.submit(p.getFormByName(is.getId()), "abort");
+            assertEquals(0, inputAction.getExecutions().size());
+            queueTaskFuture.get();
+
+            List<String> log = run.getLog(1000);
+            System.out.println(log);
+            assertTrue(expectAbortOk);
+            assertEquals("Finished: ABORTED", log.get(log.size() - 1)); // Should be aborted
+        } catch (Exception e) {
+            List<String> log = run.getLog(1000);
+            System.out.println(log);
+            assertFalse(expectAbortOk);
+            assertEquals("Yes or Abort", log.get(log.size() - 1));  // Should still be paused at input
+        }
+    }
+
+    private void addUserWithPrivs(String username, GlobalMatrixAuthorizationStrategy authorizationStrategy) {
+        authorizationStrategy.add(Jenkins.READ, username);
+        authorizationStrategy.add(Jenkins.RUN_SCRIPTS, username);
+        authorizationStrategy.add(Job.READ, username);
     }
 }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -105,6 +105,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
         return message;
     }
 
+    @Deprecated
     public boolean canSubmit() {
         Authentication a = Jenkins.getAuthentication();
         return canSettle(a);
@@ -113,6 +114,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
     /**
      * Checks if the given user can settle this input.
      */
+    @Deprecated
     public boolean canSettle(Authentication a) {
         if (submitter==null || a.getName().equals(submitter))
             return true;


### PR DESCRIPTION
See [JENKINS-26363](https://issues.jenkins-ci.org/browse/JENKINS-26363)

Also moved `InputStep.canSubmit` and `InputStep.canSettle` to `InputStepExecution` (and made them private there). I deprecated those methods in `InputStep` i.e. didn't remove them in case they are somehow in use from outside. Can remove them if we think they're not.