### PR TITLE
[FIXED JENKINS-25958] Check for already known Computers/Channels in FilePathPickle.Listener

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceActionImpl.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceActionImpl.java
@@ -52,9 +52,9 @@ public final class WorkspaceActionImpl extends WorkspaceAction implements FlowNo
 
     public WorkspaceActionImpl(FilePath workspace, FlowNode parent) {
         // TODO see FilePathPickle:
-        node = FilePathPickle.Listener.channelNames.get(workspace.getChannel());
+        node = FilePathPickle.Listener.getChannelName(workspace.getChannel());
         if (node == null) {
-            throw new IllegalStateException("no known slave for " + workspace + " among " + FilePathPickle.Listener.channelNames.values());
+            throw new IllegalStateException("no known slave for " + workspace + " among " + FilePathPickle.Listener.getChannelNames());
         }
         Jenkins j = Jenkins.getInstance();
         Node n = j == null ? null : node.isEmpty() ? j : j.getNode(node);

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/FilePathPickle.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/FilePathPickle.java
@@ -86,6 +86,18 @@ public class FilePathPickle extends Pickle {
         // TODO better to use a synchronized accessor
         @Restricted(NoExternalUse.class)
         public static final Map<VirtualChannel,String> channelNames = new WeakHashMap<VirtualChannel,String>();
+
+        static {
+            // Add channels that may already be known to Jenkins. This can be the case
+            // just after the Workflow plugins are installed (see JENKINS-25958).
+            Jenkins instance = Jenkins.getInstance();
+            if (instance != null) {
+                for (Computer c : instance.getComputers()) {
+                    channelNames.put(c.getChannel(), c.getName());
+                }
+            }
+        }
+
         @Override public void onOnline(Computer c, TaskListener l) { // TODO currently preOnline is not called for MasterComputer
             if (c instanceof Jenkins.MasterComputer) {
                 channelNames.put(c.getChannel(), c.getName());

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
@@ -41,7 +41,7 @@ public class WorkspaceListLeasePickle extends Pickle {
 
     private WorkspaceListLeasePickle(WorkspaceList.Lease lease) {
         // TODO see FilePathPickle:
-        slave = FilePathPickle.Listener.channelNames.get(lease.path.getChannel());
+        slave = FilePathPickle.Listener.getChannelName(lease.path.getChannel());
         if (slave == null) {
             throw new IllegalStateException("no known slave for " + lease.path);
         }


### PR DESCRIPTION
Hoping this is enough to fix [JENKINS-25958](https://issues.jenkins-ci.org/browse/JENKINS-25958). Is there a way we can easily test this?

@reviewbybees