### PR TITLE
Another random test failure

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/build/BuildTriggerStepRestartTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/build/BuildTriggerStepRestartTest.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.plugins.workflow.steps.build;
 
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Queue;
 import hudson.model.Result;
-import hudson.model.Run;
 import hudson.model.queue.QueueTaskFuture;
-import hudson.tasks.Shell;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -16,6 +16,7 @@ import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * @author Vivek Pandey
@@ -32,17 +33,13 @@ public class BuildTriggerStepRestartTest extends Assert {
                           public void evaluate() throws Throwable {
                               story.j.jenkins.setNumExecutors(0);
                               FreeStyleProject p1 = story.j.createFreeStyleProject("test1");
-                              p1.getBuildersList().add(new Shell("echo 'Hello World'"));
-
                               WorkflowJob foo = story.j.jenkins.createProject(WorkflowJob.class, "foo");
                               foo.setDefinition(new CpsFlowDefinition("build 'test1'", true));
-
-
                               QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
                               WorkflowRun b = q.getStartCondition().get();
                               CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
                               e.waitForSuspension();
-                              assertEquals(1, story.j.jenkins.getQueue().getItems().length);
+                              assertFreeStyleProjectsInQueue(1);
                           }
                       }
         );
@@ -50,7 +47,7 @@ public class BuildTriggerStepRestartTest extends Assert {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                assertEquals(1, story.j.jenkins.getQueue().getItems().length);
+                assertFreeStyleProjectsInQueue(1);
                 story.j.jenkins.setNumExecutors(2);
             }
         });
@@ -60,18 +57,30 @@ public class BuildTriggerStepRestartTest extends Assert {
                           public void evaluate() throws Throwable {
                               story.j.waitUntilNoActivity();
                               FreeStyleProject p1 = story.j.jenkins.getItemByFullName("test1", FreeStyleProject.class);
-                              Run r = p1.getLastBuild();
+                              FreeStyleBuild r = p1.getLastBuild();
                               assertNotNull(r);
                               assertEquals(1, r.number);
                               assertEquals(Result.SUCCESS, r.getResult());
-                              assertEquals(0, story.j.jenkins.getQueue().getItems().length);
+                              assertFreeStyleProjectsInQueue(0);
                               WorkflowJob foo = story.j.jenkins.getItemByFullName("foo", WorkflowJob.class);
                               assertNotNull(foo);
-                              r = foo.getLastBuild();
-                              assertNotNull(r);
-                              story.j.assertBuildStatusSuccess(r);
+                              WorkflowRun r2 = foo.getLastBuild();
+                              assertNotNull(r2);
+                              story.j.assertBuildStatusSuccess(r2);
                           }
                       }
         );
     }
+
+    private void assertFreeStyleProjectsInQueue(int count) {
+        Queue.Item[] items = story.j.jenkins.getQueue().getItems();
+        int actual = 0;
+        for (Queue.Item item : items) {
+            if (item.task instanceof FreeStyleProject) {
+                actual++;
+            }
+        }
+        assertEquals(Arrays.toString(items), count, actual);
+    }
+
 }


### PR DESCRIPTION
Observed:

```
java.lang.AssertionError: expected:<1> but was:<2>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:555)
	at org.junit.Assert.assertEquals(Assert.java:542)
	at org.jenkinsci.plugins.workflow.steps.build.BuildTriggerStepRestartTest$2.evaluate(BuildTriggerStepRestartTest.java:53)
```

(Naturally, by Murphy’s law, this was during `release:prepare`; never saw it before.)

I suspect the mystery second queue item was a `org.jenkinsci.plugins.workflow.job.AfterRestartTask`, which should only be in the queue for a moment, because it is a `FlyweightTask` and should be scheduled as soon as `Queue.maintain` is called, but perhaps the second step of the “story” ran just before this happened.

@reviewbybees