### PR TITLE
[JENKINS-26619] GitSCM.extensions reflection fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.4 (upcoming)
 
 ### User changes
+* JENKINS-26619: _Snippet Generator_ did not work on Git SCM extensions.
 
 ## 1.3 (Mar 04 2015)
 

--- a/step-api/pom.xml
+++ b/step-api/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/step-api/src/test/java/org/jenkinsci/plugins/workflow/structs/DescribableHelperTest.java
+++ b/step-api/src/test/java/org/jenkinsci/plugins/workflow/structs/DescribableHelperTest.java
@@ -30,6 +30,8 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.BooleanParameterValue;
 import hudson.model.Descriptor;
 import hudson.model.ParameterValue;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -459,6 +461,17 @@ public class DescribableHelperTest {
             }
             return b.toString();
         }
+    }
+
+    @Issue("JENKINS-26619")
+    @Test public void getterDescribableList() throws Exception {
+        roundTrip(GitSCM.class, map(
+            "extensions", Arrays.asList(map("$class", CleanBeforeCheckout.class.getSimpleName())),
+            // Default values for these things do not work because GitSCM fails to use @DataBoundSetter:
+            "branches", Arrays.asList(map("name", "*/master")),
+            "doGenerateSubmoduleConfigurations", false,
+            "submoduleCfg", Collections.emptyList(),
+            "userRemoteConfigs", Collections.emptyList()));
     }
 
     private static Map<String,Object> map(Object... keysAndValues) {


### PR DESCRIPTION
[JENKINS-26619](https://issues.jenkins-ci.org/browse/JENKINS-26619)

The Snippet Generator (`uninstantiate`) was confused by `GitSCMExtension`s (leaving raw objects in the suggested snippet) because `GitSCM` declares the constructor parameter as a plain old `List` whereas the getter is a `DescribableList`. `DescribableHelper` provides special treatment for JSONish lists when they could be assigned to a virtual field of `List` or `Collection` type (here is where #61 went astray), which was skipped in this case because it was seeing the field type as `DescribableList`—too narrow. But `List` was what we needed for `uncoerce` to map the `List<GitSCMExtension>` back to a JSONish list (something like `ListGitSCMExtension<Map<String,?>>`), and in fact is more relevant since ultimately `instantiate` is just constructing a `List<GitSCMExtension>` and passing it to the constructor—the declared type of the getter does not really matter.

Of course it would be desirable to fix the Git plugin to use a consistent type but in the meantime this fixes the issue.

(I did not try to fix the related case that a `@DataBoundSetter` has a different type than its getter, mainly because I know of no such example.)

As noted in JIRA, JENKINS-26143 which touches on a type mismatch in `ChoiceParameterDefinition` is not fixed by this, since in that case we really get a `List<String>` back from the getter and have no way of coercing this to the `String` that the constructor demands. But we at least get a log warning about that situation now, which may help diagnose similar problems in the future.

@reviewbybees