### PR TITLE
[JENKINS-27145] Linking to env-vars.html from UI

### DIFF
--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
@@ -34,15 +34,12 @@ below the list for Workflow specific details.
     <iframe src="${rootURL}/env-vars.html" width="100%"></iframe>
 </p>
 
-The following variables are currently not available inside a workflow script:
+The following variables are currently unavailable inside a workflow script:
 <ul>
     <li>EXECUTOR_NUMBER</li>
     <li>NODE_NAME</li>
     <li>NODE_LABELS</li>
     <li>WORKSPACE</li>
-    <li>JENKINS_URL</li>
-    <li>BUILD_URL</li>
-    <li>JOB_URL</li>
 </ul>
 
 <h4>Using Environment Variables</h4>
@@ -55,7 +52,7 @@ constructing email content when using the <code>mail</code> step:
 <pre>
     mail (to: 'devops@acme.com',
         subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
-        body: "Please go to http://builds.acme.ccom:8080/jenkins/job/foo/${env.BUILD_NUMBER}/.");
+        body: "Please go to ${env.BUILD_URL} and verify the build");
 </pre>
 
 <p/>

--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
@@ -34,28 +34,31 @@ below the list for Workflow specific details.
     <iframe src="${rootURL}/env-vars.html" width="100%"></iframe>
 </p>
 
-The following variables are only available inside <code>node</code>s (i.e. not available outside):
+The following variables are currently not available inside a workflow script:
 <ul>
     <li>EXECUTOR_NUMBER</li>
     <li>NODE_NAME</li>
     <li>NODE_LABELS</li>
     <li>WORKSPACE</li>
+    <li>JENKINS_URL</li>
+    <li>BUILD_URL</li>
+    <li>JOB_URL</li>
 </ul>
 
 <h4>Using Environment Variables</h4>
 
-Environemnt variables are injected into scripts through a variable named "<strong>env</strong>". This variable,
+Environment variables are injected into scripts through a variable named "<strong>env</strong>". This variable,
 like any other variable, can be used in the general flow of the script, or in variable substitutions e.g. when
 constructing email content when using the <code>mail</code> step:
 
-<p>
+<p/>
 <pre>
     mail (to: 'devops@acme.com',
         subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
-        body: "Please go to ${env.BUILD_URL}.");
+        body: "Please go to http://builds.acme.ccom:8080/jenkins/job/foo/${env.BUILD_NUMBER}/.");
 </pre>
-</p>
 
+<p/>
 For more on environment variables,
-<a href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#managing-the-environment">see
+<a href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#managing-the-environment" target="_blank">see
 here</a>.

--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
@@ -23,3 +23,39 @@
     but if you specify multiple parameters they must all be named:
 </p>
 <pre>stage name: 'Build', concurrency: 1</pre>
+
+<h3>Environment Variables</h3>
+
+A set of environment variables are made available to all Jenkins Job types, including Workflow Jobs.
+The following is a general list of variables (by name) that are available to all Job types. See the notes
+below the list for Workflow specific details.
+
+<p>
+    <iframe src="${rootURL}/env-vars.html" width="100%"></iframe>
+</p>
+
+The following variables are only available inside <code>node</code>s (i.e. not available outside):
+<ul>
+    <li>EXECUTOR_NUMBER</li>
+    <li>NODE_NAME</li>
+    <li>NODE_LABELS</li>
+    <li>WORKSPACE</li>
+</ul>
+
+<h4>Using Environment Variables</h4>
+
+Environemnt variables are injected into scripts through a variable named "<strong>env</strong>". This variable,
+like any other variable, can be used in the general flow of the script, or in variable substitutions e.g. when
+constructing email content when using the <code>mail</code> step:
+
+<p>
+<pre>
+    mail (to: 'devops@acme.com',
+        subject: "Job '${env.JOB_NAME}' (${env.BUILD_NUMBER}) is waiting for input",
+        body: "Please go to ${env.BUILD_URL}.");
+</pre>
+</p>
+
+For more on environment variables,
+<a href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#managing-the-environment">see
+here</a>.


### PR DESCRIPTION
See [JENKINS-27145](https://issues.jenkins-ci.org/browse/JENKINS-27145).

Please check the variables I listed as not being available outside a `node`. And if there are other exceptions that should be noted in the text help.