### PR TITLE
[FIXED JENKINS-26072] Specify alternate path to lock in WorkspaceStep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.4 (upcoming)
 
 ### User changes
+* JENKINS-26072: you can now specify a custom workspace location to lock in a `ws` step.
 * JENKINS-26619: _Snippet Generator_ did not work on Git SCM extensions.
 
 ## 1.3 (Mar 04 2015)

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/WorkspaceStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/WorkspaceStepTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.slaves.DumbSlave;
+import java.io.File;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class WorkspaceStepTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-26072")
+    @Test public void customWorkspace() throws Exception {
+        DumbSlave s = r.createSlave();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node('" + s.getNodeName() + "') {ws('custom-location') {echo pwd()}}", true));
+        r.assertLogContains(s.getRemoteFS() + File.separator + "custom-location", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
+    @Issue("JENKINS-26072")
+    @Test public void customWorkspaceConcurrency() throws Exception {
+        // Currently limited to WorkspaceList.allocate:
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        // Use master as it has 2 executors by default, whereas createSlave hardcodes 1, and I do not want to bother creating a slave by hand:
+        p.setDefinition(new CpsFlowDefinition("node {ws('custom-location') {echo pwd(); semaphore 'customWorkspace'}}", true));
+        WorkflowRun b2 = p.scheduleBuild2(0).getStartCondition().get();
+        SemaphoreStep.waitForStart("customWorkspace/1", b2);
+        WorkflowRun b3 = p.scheduleBuild2(0).getStartCondition().get();
+        SemaphoreStep.waitForStart("customWorkspace/2", b3);
+        SemaphoreStep.success("customWorkspace/1", null);
+        SemaphoreStep.success("customWorkspace/2", null);
+        while (b2.isBuilding() || b3.isBuilding()) {
+            Thread.sleep(100);
+        }
+        r.assertBuildStatusSuccess(b2);
+        r.assertBuildStatusSuccess(b3);
+        String location = new File(r.jenkins.getRootDir(), "custom-location").getAbsolutePath();
+        r.assertLogContains(location, b2);
+        r.assertLogNotContains("custom-location@", b2);
+        r.assertLogContains(location + "@2", b3);
+    }
+
+}

--- a/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -90,7 +90,8 @@ public class SnippetizerTest {
     @Test public void blockSteps() throws Exception {
         assertRoundTrip(new ExecutorStep(null), "node {\n    // some block\n}");
         assertRoundTrip(new ExecutorStep("linux"), "node('linux') {\n    // some block\n}");
-        assertRoundTrip(new WorkspaceStep(), "ws {\n    // some block\n}");
+        assertRoundTrip(new WorkspaceStep(null), "ws {\n    // some block\n}");
+        assertRoundTrip(new WorkspaceStep("loc"), "ws('loc') {\n    // some block\n}");
     }
 
     @Test public void escapes() throws Exception {

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.support.steps;
 
 import hudson.Extension;
+import hudson.Util;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,7 +36,15 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public final class WorkspaceStep extends AbstractStepImpl {
 
-    @DataBoundConstructor public WorkspaceStep() {}
+    private final String dir;
+
+    @DataBoundConstructor public WorkspaceStep(String dir) {
+        this.dir = Util.fixEmptyAndTrim(dir);
+    }
+
+    public String getDir() {
+        return dir;
+    }
 
     @Extension public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -23,42 +23,42 @@ import org.jenkinsci.plugins.workflow.support.actions.WorkspaceActionImpl;
 public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
 
     @Inject(optional=true) private transient WorkspaceStep step;
-    @StepContextParameter private transient Computer c;
-    @StepContextParameter private transient Run<?,?> r;
+    @StepContextParameter private transient Computer computer;
+    @StepContextParameter private transient Run<?,?> run;
     @StepContextParameter private transient TaskListener listener;
     @StepContextParameter private transient FlowNode flowNode;
     private BodyExecution body;
 
     @Override
     public boolean start() throws Exception {
-        Job<?,?> j = r.getParent();
-        if (!(j instanceof TopLevelItem)) {
-            throw new Exception(j + " must be a top-level job");
+        Job<?,?> job = run.getParent();
+        if (!(job instanceof TopLevelItem)) {
+            throw new Exception(job + " must be a top-level job");
         }
-        Node n = c.getNode();
-        if (n == null) {
+        Node node = computer.getNode();
+        if (node == null) {
             throw new Exception("computer does not correspond to a live node");
         }
         WorkspaceList.Lease lease;
         String dir = step.getDir();
         if (dir == null) {
-            FilePath p = n.getWorkspaceFor((TopLevelItem) j);
-            if (p == null) {
-                throw new IllegalStateException(n + " is offline");
+            FilePath baseWorkspace = node.getWorkspaceFor((TopLevelItem) job);
+            if (baseWorkspace == null) {
+                throw new IllegalStateException(node + " is offline");
             }
-            lease = c.getWorkspaceList().allocate(p);
+            lease = computer.getWorkspaceList().allocate(baseWorkspace);
         } else {
-            FilePath rootPath = n.getRootPath();
+            FilePath rootPath = node.getRootPath();
             if (rootPath == null) {
-                throw new IllegalStateException(n + " is offline");
+                throw new IllegalStateException(node + " is offline");
             }
-            FilePath p = rootPath.child(dir);
+            FilePath baseWorkspace = rootPath.child(dir);
             // TODO acquire would block the CPS VM thread and not survive restarts.
             // Could force the exact path to be acquired only by setting up a background thread (w/ onResume) to block,
             // or adding core API to register a callback listener when any existing lease is released.
-            lease = c.getWorkspaceList().allocate(p);
+            lease = computer.getWorkspaceList().allocate(baseWorkspace);
         }
-        FilePath workspace = lease.path;
+        FilePath workspace = lease.path; // may be baseWorkspace + @2, @3, etc.
         flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
         listener.getLogger().println("Running in " + workspace);
         body = getContext().newBodyInvoker()

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/config.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/config.jelly
@@ -24,4 +24,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core"/>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Custom Location" field="dir">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/help-dir.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/help-dir.html
@@ -1,0 +1,19 @@
+<p>
+    A workspace is automatically allocated for you with the <code>node</code> step,
+    or you can get an alternate workspace with this <code>ws</code> step,
+    but by default the location is chosen automatically.
+    (Something like <code>SLAVE_ROOT/workspace/JOB_NAME@2</code>.)
+</p>
+<p>
+    You can instead specify a path here and that workspace will be locked instead.
+    (The path may be relative to the slave root, or absolute.)
+</p>
+<p>
+    If concurrent builds ask for the same workspace, a directory with a suffix such as <code>@2</code> may be locked instead.
+    Currently there is no option to wait to lock the exact directory requested;
+    if you need to enforce that behavior, you can either fail (<code>error</code>) when <code>pwd</code> indicates that you got a different directory,
+    or you may enforce serial execution of this part of the build by some other means such as <code>stage name: '…', concurrency: 1</code>.
+</p>
+<p>
+    If you do not care about locking, just use the <code>dir</code> step to change current directory.
+</p>


### PR DESCRIPTION
[JENKINS-26072](https://issues.jenkins-ci.org/browse/JENKINS-26072)

While this sounds similar to `AbstractProject.customWorkspace`, that only selects an alternate directory to run the build in, and does no locking whatsoever, which you could already do in a Workflow with `dir`.

@reviewbybees