### PR TITLE
[JENKINS-26122] Prepend parallel step execution logs with the branch label

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.4 (upcoming)
 
 ### User changes
+* JENKINS-26122: Prepend `parallel` step execution logs with the branch label.
 * JENKINS-26619: _Snippet Generator_ did not work on Git SCM extensions.
 
 ## 1.3 (Mar 04 2015)

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
@@ -357,6 +357,7 @@ public class ParallelStepTest extends SingleJobTestBase {
                 assertBuildCompletedSuccessfully();
 
                 // Check that the individual labeled lines are as expected
+                //System.out.println(b.getLog());
                 List<String> logLines = b.getLog(50);
                 assertGoodLabeledLogs(logLines);
 
@@ -381,7 +382,8 @@ public class ParallelStepTest extends SingleJobTestBase {
                         String.format("[%s] Running: Print Message", label),
                         String.format("[%s] echo %s", label, label)
                 );
-                assertTrue(possibleLogLines.contains(logLine));
+                boolean contains = possibleLogLines.contains(logLine);
+                assertTrue(contains);
             }
             private void assertGoodSequence(String label, List<String> logLines) {
                 String running = String.format("[%s] Running: Print Message", label);

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
@@ -279,7 +279,7 @@ public class ParallelStepTest extends SingleJobTestBase {
         for (Row row : t.getRows()) {
             ParallelLabelAction a = row.getNode().getAction(ParallelLabelAction.class);
             if (a!=null)
-                actual.add(a.getBranchName());
+                actual.add(a.getThreadName());
         }
 
         assertEquals(Arrays.asList(expected),actual);

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
@@ -9,9 +9,9 @@ import static java.util.Arrays.*;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.SingleJobTestBase;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep;
-import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep.ParallelLabelAction;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStepException;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -277,7 +277,7 @@ public class ParallelStepTest extends SingleJobTestBase {
         List<String> actual = new ArrayList<String>();
 
         for (Row row : t.getRows()) {
-            ParallelLabelAction a = row.getNode().getAction(ParallelLabelAction.class);
+            ThreadNameAction a = row.getNode().getAction(ThreadNameAction.class);
             if (a!=null)
                 actual.add(a.getThreadName());
         }

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/actions/BodyExecutionLabelAction.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/actions/BodyExecutionLabelAction.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2014, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.actions;
+
+// TODO: Seems like this should be in the step-api module alongside BodyExecution. Can't go there though because of module dependencies, which I dare not touch :)
+// I'd have thought the workflow-api module (where LabelAction lives) would be the one module that all other modules would depend on, but that's not he case.
+
+/**
+ * Body execution label.
+ * <p>
+ * Used to label the branches of an the asynchronous execution represented by a
+ * BodyExecution.
+ * </p>
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public abstract class BodyExecutionLabelAction extends LabelAction {
+
+    private final String bodyLabel;
+
+    public BodyExecutionLabelAction(String displayName) {
+        super(displayName);
+        this.bodyLabel = displayName;
+    }
+
+    public final String getBodyLabel() {
+        return bodyLabel;
+    }
+}

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/actions/ThreadNameAction.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/actions/ThreadNameAction.java
@@ -23,28 +23,17 @@
  */
 package org.jenkinsci.plugins.workflow.actions;
 
-// TODO: Seems like this should be in the step-api module alongside BodyExecution. Can't go there though because of module dependencies, which I dare not touch :)
-// I'd have thought the workflow-api module (where LabelAction lives) would be the one module that all other modules would depend on, but that's not he case.
+import hudson.model.Action;
+
+import javax.annotation.Nonnull;
 
 /**
- * Body execution label.
- * <p>
- * Used to label the branches of an the asynchronous execution represented by a
- * BodyExecution.
- * </p>
+ * Thread name action.
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public abstract class BodyExecutionLabelAction extends LabelAction {
+public interface ThreadNameAction extends Action {
 
-    private final String bodyLabel;
-
-    public BodyExecutionLabelAction(String displayName) {
-        super(displayName);
-        this.bodyLabel = displayName;
-    }
-
-    public final String getBodyLabel() {
-        return bodyLabel;
-    }
+    @Nonnull
+    String getThreadName();
 }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -4,7 +4,7 @@ import com.cloudbees.groovy.cps.Outcome;
 import groovy.lang.Closure;
 import hudson.Extension;
 import hudson.model.TaskListener;
-import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.BodyExecutionLabelAction;
 import org.jenkinsci.plugins.workflow.cps.CpsVmThreadOnly;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
@@ -47,11 +47,11 @@ public class ParallelStep extends Step {
     }
 
     @PersistIn(FLOW_NODE)
-    public static class ParallelLabelAction extends LabelAction {
+    public static class ParallelLabelAction extends BodyExecutionLabelAction {
         private final String branchName;
 
         ParallelLabelAction(String branchName) {
-            super(null);
+            super(branchName);
             this.branchName = branchName;
         }
 

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -62,10 +62,6 @@ public class ParallelStep extends Step {
             return "Parallel branch: "+branchName;
         }
 
-        public String getBranchName() {
-            return branchName;
-        }
-
         @Nonnull
         @Override
         public String getThreadName() {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -4,8 +4,6 @@ import com.cloudbees.groovy.cps.Outcome;
 import groovy.lang.Closure;
 import hudson.Extension;
 import hudson.model.TaskListener;
-import org.jenkinsci.plugins.workflow.actions.LabelAction;
-import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsVmThreadOnly;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
@@ -14,7 +12,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
-import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,27 +43,6 @@ public class ParallelStep extends Step {
     @CpsVmThreadOnly("CPS program calls this, which is run by CpsVmThread")
     public StepExecution start(StepContext context) throws Exception {
         return new ParallelStepExecution(this, context);
-    }
-
-    @PersistIn(FLOW_NODE)
-    public static class ParallelLabelAction extends LabelAction implements ThreadNameAction {
-        private final String branchName;
-
-        ParallelLabelAction(String branchName) {
-            super(null);
-            this.branchName = branchName;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Parallel branch: "+branchName;
-        }
-
-        @Nonnull
-        @Override
-        public String getThreadName() {
-            return branchName;
-        }
     }
 
     @PersistIn(PROGRAM)

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -4,7 +4,8 @@ import com.cloudbees.groovy.cps.Outcome;
 import groovy.lang.Closure;
 import hudson.Extension;
 import hudson.model.TaskListener;
-import org.jenkinsci.plugins.workflow.actions.BodyExecutionLabelAction;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsVmThreadOnly;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
@@ -13,6 +14,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +49,7 @@ public class ParallelStep extends Step {
     }
 
     @PersistIn(FLOW_NODE)
-    public static class ParallelLabelAction extends BodyExecutionLabelAction {
+    public static class ParallelLabelAction extends LabelAction implements ThreadNameAction {
         private final String branchName;
 
         ParallelLabelAction(String branchName) {
@@ -61,6 +63,12 @@ public class ParallelStep extends Step {
         }
 
         public String getBranchName() {
+            return branchName;
+        }
+
+        @Nonnull
+        @Override
+        public String getThreadName() {
             return branchName;
         }
     }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -53,7 +53,7 @@ public class ParallelStep extends Step {
         private final String branchName;
 
         ParallelLabelAction(String branchName) {
-            super(branchName);
+            super(null);
             this.branchName = branchName;
         }
 

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
@@ -1,17 +1,22 @@
 package org.jenkinsci.plugins.workflow.cps.steps;
 
 import groovy.lang.Closure;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
-import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep.ParallelLabelAction;
+import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep.ResultHandler;
 import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+
+import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.FLOW_NODE;
 
 /**
  * {@link StepExecution} for {@link ParallelStep}.
@@ -55,4 +60,25 @@ class ParallelStepExecution extends StepExecution {
     }
 
     private static final long serialVersionUID = 1L;
+
+    @PersistIn(FLOW_NODE)
+    private static class ParallelLabelAction extends LabelAction implements ThreadNameAction {
+        private final String branchName;
+
+        ParallelLabelAction(String branchName) {
+            super(null);
+            this.branchName = branchName;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Parallel branch: "+branchName;
+        }
+
+        @Nonnull
+        @Override
+        public String getThreadName() {
+            return branchName;
+        }
+    }
 }

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -270,7 +270,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
                         }
                     } finally {
                         if (prefix != null) {
-                            // It's a LogLinePrefixOutputFilter (see above). Force an EOL.
                             ((LogLinePrefixOutputFilter)logger).forceEol();
                         }
                     }

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -302,7 +302,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
             if (threadNameAction != null) {
                 return threadNameAction.getThreadName();
             } else {
-                // This exec body does not have a body label. Stop now.
+                // This exec body does not impl ThreadNameAction. Stop now.
                 return null;
             }
         }


### PR DESCRIPTION
See [JENKINS-26122](https://issues.jenkins-ci.org/browse/JENKINS-26122)

Prefixes log entries from the `parallel` step using the branch name. Added `BodyExecutionLabelAction` (currently located in the `workflow-api` module, which seems wrong ... see comment in `BodyExecutionLabelAction`) and modified `ParallelLabelAction` to extend it.

Example output - see the `[a]` and `[b]` prefixes on some of the log lines in the following sample.

```
Started by user anonymous
Running: Allocate node : Start
Running on master in /Users/tfennelly/projects/jenkins-plugins/workflow-plugin/aggregator/work/jobs/Workflwo/workspace
Running: Allocate node : Body : Start
Running: Execute sub-workflows in parallel : Start
[a] Running: Parallel branch: a
[b] Running: Parallel branch: b
[a] Running: Print Message
[a] echo a
[a] Running: Print Message
[a] echo a
[a] Running: Print Message
[a] echo a
Running: Execute sub-workflows in parallel : Body : End
[b] Running: Print Message
[b] echo b
[b] Running: Print Message
[b] echo b
[b] Running: Print Message
[b] echo b
Running: Execute sub-workflows in parallel : Body : End
Running: Execute sub-workflows in parallel : End
Running: Allocate node : Body : End
Running: Allocate node : End
Running: End of Workflow
Finished: SUCCESS
```

@reviewbybees please