### PR TITLE
[JENKINS-26034] add option to fail fast on parallel branch failure.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.4 (upcoming)
 
 ### User changes
+* JENKINS-26034: added `failFast` option to the `parallel` step.
 * JENKINS-26085: added `credentialsId` to the `git` step.
 * JENKINS-26121: record the approver of an `input` step in build history.
 * JENKINS-26122: Prepend `parallel` step execution logs with the branch label.

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/parallel/ParallelStepTest.java
@@ -81,7 +81,7 @@ public class ParallelStepTest extends SingleJobTestBase {
                     "      b: { error 'died' },",
 
                         // make sure this branch takes longer than a
-                    "      a: { sleep 3; writeFile text: '', file: 'b.done' }",
+                    "      a: { sleep 3; writeFile text: '', file: 'a.done' }",
                     "    )",
                     "    assert false;",
                     "  } catch (ParallelStepException e) {",
@@ -93,7 +93,7 @@ public class ParallelStepTest extends SingleJobTestBase {
 
                 startBuilding().get();
                 assertBuildCompletedSuccessfully();
-                assert jenkins().getWorkspaceFor(p).child("b.done").exists();
+                assert jenkins().getWorkspaceFor(p).child("a.done").exists();
 
                 buildTable();
                 shouldHaveParallelStepsInTheOrder("b","a");
@@ -120,11 +120,12 @@ public class ParallelStepTest extends SingleJobTestBase {
                     "      b: { error 'died' },",
 
                         // make sure this branch takes longer than a
-                    "      a: { sleep 10; writeFile text: '', file: 'b.done' },",
+                    "      a: { sleep 25; writeFile text: '', file: 'a.done' },",
                     "      failFast: true",
                     "    )",
                     "    assert false",
                     "  } catch (ParallelStepException e) {",
+                    "    echo e.toString()",
                     "    assert e.name=='b'",
                     "    assert e.cause instanceof AbortException",
                     "  }",
@@ -133,7 +134,7 @@ public class ParallelStepTest extends SingleJobTestBase {
 
                 startBuilding().get();
                 assertBuildCompletedSuccessfully();
-                Assert.assertFalse("b should have aborted", jenkins().getWorkspaceFor(p).child("b.done").exists());
+                Assert.assertFalse("a should have aborted", jenkins().getWorkspaceFor(p).child("a.done").exists());
 
             }
         });

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
@@ -39,7 +39,7 @@ class ParallelStepExecution extends StepExecution {
         CpsStepContext cps = (CpsStepContext) getContext();
         CpsThread t = CpsThread.current();
 
-        ResultHandler r = new ResultHandler(cps);
+        ResultHandler r = new ResultHandler(cps, this, parallelStep.isFailFast());
 
         for (Entry<String,Closure> e : parallelStep.closures.entrySet()) {
             BodyExecution body = cps.newBodyInvoker(t.getGroup().export(e.getValue()))

--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep/config.jelly
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep/config.jelly
@@ -27,12 +27,14 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:block>
         <p>
-            (No visual configuration.) Takes a map from branch names to closures:
+            (No visual configuration.) Takes a map from branch names to closures and an optional argument <code>failFast</code>
+             which will terminate all branches upon a failure in any other branch:
         </p>
         <pre>parallel firstBranch: {
     // do something
 }, secondBranch: {
     // do something else
-}</pre>
+},
+failFast: true|false</pre>
     </f:block>
 </j:jelly>


### PR DESCRIPTION
Added an option "failFast: true" to the parallel step options that
will terminate all running branches inside a parallel step if one of the
branches fails.
