### PR TITLE
Still trying to diagnose failures on WorkflowTest.executorStepRestart

### DIFF
--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -348,6 +348,9 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
 
     @Override protected void onLoad() {
         super.onLoad();
+        if (completed != null) {
+            throw new IllegalStateException("double onLoad of " + this);
+        }
         if (execution != null) {
             execution.onLoad();
             execution.addListener(new GraphL());


### PR DESCRIPTION
After #85 was merged, I now see a [different failure](https://jenkins.ci.cloudbees.com/job/plugins/job/workflow-plugin/org.jenkins-ci.plugins.workflow$workflow-aggregator/1049/testReport/junit/org.jenkinsci.plugins.workflow/WorkflowTest/executorStepRestart/). Again `isBuilding` remains true, and as before we see

```
Started
Running: Allocate node : Start
Still waiting to schedule task
Waiting for next available executor
Resuming build
Resuming build
```

for a while. The duplicated message looks suspicious (hence this patch). Then we get

```
… org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: demo #1 completed: SUCCESS
```

and then we start seeing

```
Started
Running: Allocate node : Start
Still waiting to schedule task
Waiting for next available executor
Resuming build
Resuming build
Running on slave0 in /tmp/hudson4729640265695080163test/workspace/demo
Running: Allocate node : Body : Start
Running: Print Message
OK ran
Running: Allocate node : Body : End
Running: Allocate node : End
Running: End of Workflow
Finished: SUCCESS
```

for a while, though the build is still considered to be `building`, and then after a bit it settles into

```
Started
Running: Allocate node : Start
Still waiting to schedule task
Waiting for next available executor
Resuming build
Resuming build
Running on slave0 in /tmp/hudson4729640265695080163test/workspace/demo
Running: Allocate node : Body : Start
Running: Print Message
OK ran
Running: Allocate node : Body : End
Running: Allocate node : End
Running: End of Workflow
Finished: SUCCESS
Running on slave0 in /tmp/hudson4729640265695080163test/workspace/demo
```

which makes even less sense.

@reviewbybees