### PR TITLE
Update baseline to 1.596.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,10 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.5 (upcoming)
 
+* Now based on Jenkins core 1.596.1.
+
 ## 1.4 (Mar 16 2015)
 
-### User changes
 * [JENKINS-26034](https://issues.jenkins-ci.org/browse/JENKINS-26034): added `failFast` option to the `parallel` step.
 * [JENKINS-26085](https://issues.jenkins-ci.org/browse/JENKINS-26085): added `credentialsId` to the `git` step.
 * [JENKINS-26121](https://issues.jenkins-ci.org/browse/JENKINS-26121): record the approver of an `input` step in build history.
@@ -20,7 +21,6 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.3 (Mar 04 2015)
 
-### User changes
 * [JENKINS-25958](https://issues.jenkins-ci.org/browse/JENKINS-25958): the basic `node` step did not work if Workflow was dynamically installed in Jenkins (with no restart).
 * [JENKINS-26363](https://issues.jenkins-ci.org/browse/JENKINS-26363): anyone permitted to cancel a flow build should also be permitted to cancel an `input` step.
 * [JENKINS-26093](https://issues.jenkins-ci.org/browse/JENKINS-26093): `build` can now accept `parameters` in a more uniform (and sandbox-friendly) syntax, and the _Snippet Generator_ proposes them based on the actual parameter definitions of the downstream job.
@@ -41,7 +41,6 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.2 (Jan 24 2015)
 
-### User changes
 * [JENKINS-26101](https://issues.jenkins-ci.org/browse/JENKINS-26101): the complete workflow script can now be loaded from an SCM repository of your choice.
 * [JENKINS-26149](https://issues.jenkins-ci.org/browse/JENKINS-26149): the `build` step did not survive Jenkins restarts while running.
 * [JENKINS-25570](https://issues.jenkins-ci.org/browse/JENKINS-25570): added `waitUntil` step.
@@ -54,7 +53,6 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.1 (Dec 09 2014)
 
-### User changes
 * `input` step did not survive Jenkins restarts.
 * `env` did not work in sandbox mode.
 * `load` step was not available in the _Snippet Generator_.
@@ -65,100 +63,4 @@ Only noting significant user-visible or major API changes, not internal code cle
 ## 1.0
 
 No changes from 1.0-beta-1.
-
-## 1.0-beta-1
-
-### User changes
-* Fixes to start time, duration, and similar aspects of flow runs.
-
-### API changes
-* `BodyInvoker` and `BodyExecutionCallback` replace `StepContext.invokeBodyLater` and `BodyExecution.addCallback` for better control of execution behavior.
-
-## 0.1-beta-8
-
-### User changes
-* `scm` step renamed `checkout`.
-* New syntax for structured objects, enabling more concise scripts without needing to import Jenkins-specific classes. _Incompatible syntax change_ for callers of `checkout` and `step` steps. Snippet generator and documentation updated to match.
-* Added `timeout` step.
-* Better cancellation behavior when the stop button is pressed, for example killing all branches of `parallel`.
-* Fleshed out Groovy operators supported.
-* Friendlier error in case a step is invoked without its required context, such as `sh` outside `node`.
-* The flow graph table is now on its own page, accessible via the _Running Steps_ link from a build.
-* A visual graph of flow nodes is available from a hidden link `graphViz`. Similarly, `flowGraph` links to a simple list of all nodes, including merge nodes that would not be visible in the regular table.
-* More useful information about the graph in the REST API for a flow build.
-* Fixes to Groovy Git library.
-* Fixed form validation for Groovy script.
-* Fixed thread leak.
-* Script security fix when the Email Ext plugin is also installed.
-
-### API changes
-* `invokeBodyLater` now returns a new `BodyExecution`, mainly to support cancellation of the body.
-* Fields in a `StepExecution` marked `@Inject` or `@StepContextParameter` will now be reinjected when resuming from disk.
-
-## 0.1-beta-7
-* Moved `input` and `build` steps to the `workflow-support` plugin (from the `workflow-basic-steps` plugin).
-* Added a label to `build` step nodes based on the display name of the downstream job.
-* Message was missing from _Paused for Input_ page.
-* Changed snippet generator to quote multiline strings using `'''`; quoting with `/` (slashy strings) was not working well.
-* Added `PauseAction` to the API for potential use from visualizations.
-* Added support for `WorkspaceAction` to report labels, for potential use from visualizations.
-* Fixed environment variable handling when running builds on slaves, which had regressed with the introduction of `env` in beta 5.
-* No longer enforcing workspace-relative paths from `dir`, `readFile`, and `writeFile` steps.
-* Added `FlowInterruptedException` to API.
-* Showing the flow build as aborted, rather than failed, if a user rejects an `input` prompt.
-* Flow termination from a `stage` step (due to a superseding build) can now be handled using `catch` and `finally` blocks.
-* Fixed handling of `&&` and `||` operators in Groovy.
-* Git-controlled Groovy library now expects sources to be under a directory `src/` rather than at top level. Also no longer need to pass a `this` reference to a helper class from the main script. See [documentation](cps-global-lib/README.md) for this feature.
-
-## 0.1-beta-6
-* Now based on Jenkins core 1.580.1.
-* Elementary support for tracking workspaces used by a flow. Currently visible only by clicking on the flow node starting a `node` (or `ws`) step.
-* Properly reporting the job owning an executor slot (`node` step); useful for CloudBees Folders Plus controlled slaves, and perhaps other plugins as well.
-* Updated dependencies on Git and Subversion plugins to pick up important fixes.
-* Some utility functions used by steps with unusual configuration factored out into a new API class `DescribableHelper`.
-
-## 0.1-beta-5
-* _Incompatible_: some steps formerly using `value` as the name for a principal parameter now use a more descriptive name. You can still call them without specifying the field name; the difference is only visible if you were also specifying other optional parameters.
-* `evaluate` function may now be used to evaluate Groovy code CPS-transformed as if it were part of the main script. New `load` step lets you load and run a Groovy script from the workspace. A work in progress.
-* New plugin `workflow-cps-global-lib` allowing a global shared library for scripts.
-* Flow scripts may now be run in a Groovy sandbox to allow regular users to define them without administrator approval. More work is likely needed to supply a reasonable method call whitelist out of the box.
-* Flow definition page has a section letting you visually configure a step and see the corresponding Groovy code to run it.
-* Added some general inline help to the flow definition page regarding script syntax.
-* Added `readFile` and `writeFile` steps to manipulate workspace files easily.
-* Added `tool` step to run a tool installer on the current node.
-* Added `bat` step to run commands on Windows nodes.
-* `build` step now sets an appropriate cause on the downstream build.
-* `build` step may now take parameters.
-* Faster display of output from shell steps.
-* Robustness improvements for shell steps, especially in the face of disconnecting or rebooting slaves.
-* Improved handling of parameter binding for classes using `@DataBoundSetter`.
-* Scripts can now read and write properties of a magic variable `env` to get and set environment variables applicable to `sh` and similar steps. Overridden variables are also visible from the REST API.
-* Fixed icon in flow execution table.
-* Not publishing `workflow-stm` plugin unless and until it is made functional. Existing installations may be deleted.
-
-## 0.1-beta-4
-* Requires Jenkins core 1.580 or later.
-* Better behavior on cloud slaves integrated with the Durable Task plugin.
-* Allowing a build in the middle of a shell step to be interrupted.
-* Allowed `SCMStep` to be extended from other SCM plugins.
-* Added `StageAction` and `TimingAction` for the benefit of visualizations.
-* Allowing `build` to start builds of other workflows, not just freestyle projects.
-
-## 0.1-beta-3
-* Requires Jenkins core 1.577 or later.
-* Support for running some builders and post-build actions from a flow using the same code as in freestyle projects. See [here](basic-steps/CORE-STEPS.md) for details.
-* Added `catchError` step.
-
-## 0.1-beta-2
-
-* Simplified threading model for Groovy engine.
-* Added `build` step.
-* `StepExecution` now separated from `Step`.
-* `steps.` prefix now optional (only needed to disambiguate defined steps from other user functions with the same name). `with.` prefix no longer in use.
-* Requires Jenkins core 1.572 or later.
-* Removed custom `mercurial` step; can now use a generic `scm` step (for example with the Mercurial plugin 1.51-beta-2 or later).
-* Hyperlinking of prompts from the `input` step.
-
-## 0.1-beta-1
-
-First public release.
+See [here](https://github.com/jenkinsci/workflow-plugin/blob/cdca218ca11e127d97543a2e209803708c5af9d8/CHANGES.md) for changes in pre-1.0 betas.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Read the [tutorial](TUTORIAL.md) to get started writing workflows.
 # Installation
 
 Releases are available on the Jenkins update center.
-You need to be running a sufficiently recent Jenkins release, currently an LTS in the 1.580.x line or newer, or a newer weekly release.
+You need to be running a sufficiently recent Jenkins release, currently an LTS in the 1.596.x line or newer, or a newer weekly release.
 See the [changelog](CHANGES.md) for news.
 
 For OSS Jenkins users, install _Workflow: Aggregator_ (its dependencies will be pulled in automatically).

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2,7 +2,7 @@ This document is intended for new users of the Workflow feature to learn how to 
 
 # Getting started
 
-You need to be running Jenkins 1.580.1 or later.
+You need to be running Jenkins 1.580.1 or later (1.596.1 or later for more recent features).
 If you have not already done so, make sure Workflow is installed: go to the Plugin Manager and install _Workflow: Aggregator_ and restart Jenkins.
 Also make sure the _Git_ and _JUnit_ plugins are installed and up to date.
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/input/InputStepTest.java
@@ -33,7 +33,6 @@ import hudson.model.User;
 import hudson.model.queue.QueueTaskFuture;
 
 
-import java.util.Arrays;
 import java.util.List;
 
 import hudson.security.ACL;
@@ -54,7 +53,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
-import org.jvnet.hudson.test.RandomlyFails;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -130,7 +128,6 @@ public class InputStepTest extends Assert {
         assertEquals("alice", action.getUserId());;
     }
 
-    @RandomlyFails("TODO pending AtomicFileWriter.commit diagnostic improvement in 1.591")
     @Test
     @Issue("JENKINS-26363")
     public void test_cancel_run_by_input() throws Exception {

--- a/cps-global-lib/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepository.java
+++ b/cps-global-lib/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepository.java
@@ -21,20 +21,12 @@ public class WorkflowLibRepository extends FileBackedHttpGitRepository implement
     }
 
     private static File workspace() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        return new File(j.root, "workflow-libs");
+        return new File(Jenkins.getActiveInstance().root, "workflow-libs");
     }
 
     @Override
     protected void checkPushPermission() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        j.checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.RUN_SCRIPTS);
     }
 
     public String getIconFileName() {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -85,10 +85,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
             throw new IOException("can only check out SCM into a Run");
         }
         Run<?,?> build = (Run<?,?>) _build;
-        Node node = Jenkins.getInstance(); // TODO offer to select a slave based on a configured Label
-        if (node == null) {
-            throw new IOException("Jenkins is not running");
-        }
+        Node node = Jenkins.getActiveInstance(); // TODO offer to select a slave based on a configured Label
         if (build.getParent() instanceof TopLevelItem) {
             FilePath baseWorkspace = node.getWorkspaceFor((TopLevelItem) build.getParent());
             if (baseWorkspace == null) {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -37,7 +37,6 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.RunAction2;
-import org.jenkinsci.plugins.workflow.support.DefaultStepContext;
 import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -58,7 +57,7 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
 
     @Override public EnvVars getEnvironment() throws IOException, InterruptedException {
         if (ownerEnvironment == null) {
-            ownerEnvironment = DefaultStepContext.getEnvironment(owner, new LogTaskListener(LOGGER, Level.INFO));
+            ownerEnvironment = owner.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
         }
         EnvVars e = new EnvVars(ownerEnvironment);
         e.putAll(env);

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -192,10 +192,7 @@ import org.kohsuke.stapler.StaplerResponse;
     public HttpResponse doGenerateSnippet(StaplerRequest req, @QueryParameter String json) throws Exception {
         // TODO is there not an easier way to do this?
         JSONObject jsonO = JSONObject.fromObject(json);
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
+        Jenkins j = Jenkins.getActiveInstance();
         Class<?> c = j.getPluginManager().uberClassLoader.loadClass(jsonO.getString("stapler-class"));
         Descriptor<?> descriptor = j.getDescriptor(c.asSubclass(Step.class));
         Object o;

--- a/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -88,11 +88,7 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
         private String remote;
 
         @Override public boolean start() throws Exception {
-            Jenkins j = Jenkins.getInstance();
-            if (j == null) {
-                throw new IllegalStateException("Jenkins is not running");
-            }
-            for (Computer c : j.getComputers()) {
+            for (Computer c : Jenkins.getActiveInstance().getComputers()) {
                 if (c.getChannel() == ws.getChannel()) {
                     node = c.getName();
                     break;

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
@@ -108,7 +108,7 @@ class AfterRestartTask extends AbstractQueueTask implements Queue.FlyweightTask,
         return new Body(run);
     }
 
-    /* TODO 1.592+: @Override */ public Authentication getDefaultAuthentication(Queue.Item item) {
+    @Override public Authentication getDefaultAuthentication(Queue.Item item) {
         return getDefaultAuthentication();
     }
 

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -324,7 +324,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         return ACL.SYSTEM;
     }
 
-    /* TODO 1.592+: @Override */ public Authentication getDefaultAuthentication(Queue.Item item) {
+    @Override public Authentication getDefaultAuthentication(Queue.Item item) {
         return getDefaultAuthentication();
     }
 

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -265,11 +265,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public int getQuietPeriod() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        return quietPeriod != null ? quietPeriod : j.getQuietPeriod();
+        return quietPeriod != null ? quietPeriod : Jenkins.getActiveInstance().getQuietPeriod();
     }
 
     @Restricted(DoNotUse.class) // for config-quietPeriod.jelly
@@ -372,11 +368,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public TopLevelItemDescriptor getDescriptor() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        return (DescriptorImpl) j.getDescriptorOrDie(WorkflowJob.class);
+        return (DescriptorImpl) Jenkins.getActiveInstance().getDescriptorOrDie(WorkflowJob.class);
     }
 
     @Override public Map<TriggerDescriptor, Trigger<?>> getTriggers() {

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -42,7 +42,6 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.Label;
 import hudson.model.Node;
-import hudson.model.PermalinkProjectAction;
 import hudson.model.Queue;
 import hudson.model.ResourceList;
 import hudson.model.RunMap;
@@ -73,7 +72,6 @@ import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
-import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.triggers.SCMTriggerItem;
@@ -88,7 +86,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
-public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements BuildableItem, ModelObjectWithChildren, LazyBuildMixIn.LazyLoadingJob<WorkflowJob,WorkflowRun>, ParameterizedJobMixIn.ParameterizedJob, TopLevelItem, Queue.FlyweightTask, SCMTriggerItem {
+public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements BuildableItem, LazyBuildMixIn.LazyLoadingJob<WorkflowJob,WorkflowRun>, ParameterizedJobMixIn.ParameterizedJob, TopLevelItem, Queue.FlyweightTask, SCMTriggerItem {
 
     private FlowDefinition definition;
     private DescribableList<Trigger<?>,TriggerDescriptor> triggers = new DescribableList<Trigger<?>,TriggerDescriptor>(this);
@@ -350,17 +348,6 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
 
     @Override public ResourceList getResourceList() {
         return ResourceList.EMPTY;
-    }
-
-    // TODO as of 1.577 implemented in Job, can delete override (and redundant implementation of ModelObjectWithChildren)
-    @Override public ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception {
-        ContextMenu menu = new ContextMenu();
-        for (PermalinkProjectAction.Permalink p : getPermalinks()) {
-            if (p.resolve(this) != null) {
-                menu.add(p.getId(), p.getDisplayName());
-            }
-        }
-        return menu;
     }
 
     @Override public String getPronoun() {

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -511,21 +511,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
                 l.onChangeLogParsed(this, scm, listener, cls);
             }
         }
-        String node = null;
-        // TODO: switch to FilePath.toComputer in 1.571
-        Jenkins j = Jenkins.getInstance();
-        if (j != null) {
-            for (Computer c : j.getComputers()) {
-                if (workspace.getChannel() == c.getChannel()) {
-                    node = c.getName();
-                    break;
-                }
-            }
-        }
-        if (node == null) {
+        // TODO JENKINS-26096 prefer a variant returning only Computer.name even if offline
+        Computer computer = workspace.toComputer();
+        if (computer == null) {
             throw new IllegalStateException();
         }
-        checkouts.add(new SCMCheckout(scm, node, workspace.getRemote(), changelogFile, pollingBaseline));
+        checkouts.add(new SCMCheckout(scm, computer.getName(), workspace.getRemote(), changelogFile, pollingBaseline));
     }
 
     static final class SCMCheckout {

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -567,7 +567,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
                 } else {
                     Jenkins jenkins = Jenkins.getInstance();
                     if (jenkins == null) {
-                        throw new IOException("Jenkins is not running");
+                        throw new IOException("Jenkins is not running"); // do not use Jenkins.getActiveInstance() as that is an ISE
                     }
                     WorkflowJob j = jenkins.getItemByFullName(job, WorkflowJob.class);
                     if (j == null) {

--- a/job/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
+++ b/job/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
@@ -24,14 +24,14 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:p="/lib/hudson/project">
     <l:side-panel>
         <l:tasks>
             <j:set var="buildUrl" value="${h.decompose(request)}"/>
             <l:task icon="images/24x24/up.png" href="${it.upUrl}" title="${%Back to Project}" contextMenu="false"/>
             <l:task icon="images/24x24/search.png" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
             <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/changes" title="${%Changes}"/>
-            <l:task icon="images/24x24/terminal.png" href="${buildUrl.baseUrl}/console" title="${%Console Output}"/> <!-- TODO 1.570: <p:console-link/> -->
+            <p:console-link/>
             <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/configure" title="${h.hasPermission(it,it.UPDATE)?'%Edit Build Information':'%View Build Information'}"/>
             <st:include page="delete.jelly"/>
             <st:include page="actions.jelly"/>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>1.596.1</version>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
@@ -40,10 +40,6 @@ public abstract class AbstractStepImpl extends Step {
      * Creates an {@link Injector} that performs injection to {@link Inject} and {@link StepContextParameter}.
      */
     protected static Injector prepareInjector(final StepContext context, @Nullable final Step step) {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        return j.getInjector().createChildInjector(new ContextParameterModule(step,context));
+        return Jenkins.getActiveInstance().getInjector().createChildInjector(new ContextParameterModule(step,context));
     }
 }

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -28,12 +28,8 @@ import hudson.model.Executor;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
@@ -47,34 +43,17 @@ import jenkins.model.InterruptedBuildAction;
  */
 public final class FlowInterruptedException extends InterruptedException {
 
-    private static final Logger LOG = Logger.getLogger(FlowInterruptedException.class.getName());
-
     private final @Nonnull Result result;
     private final @Nonnull List<CauseOfInterruption> causes;
-    private /*final*/ transient @Nonnull List<CauseOfInterruption> allCauses;
 
     /**
      * Creates a new exception.
      * @param result the desired result for the flow, typically {@link Result#ABORTED}
-     * @param causes any indications (should be {@link Serializable})
+     * @param causes any indications
      */
     public FlowInterruptedException(@Nonnull Result result, @Nonnull CauseOfInterruption... causes) {
         this.result = result;
-        allCauses = Arrays.asList(causes);
-        this.causes = new ArrayList<CauseOfInterruption>();
-        for (CauseOfInterruption cause : causes) {
-            if (cause instanceof Serializable) {
-                this.causes.add(cause);
-            } else {
-                // TODO 1.591+ this is impossible as CauseOfInterruption implements Serializable
-                LOG.log(Level.WARNING, "nonserializable CauseOfInterruption: {0}", cause.getClass().getName());
-            }
-        }
-    }
-
-    private Object readResolve() {
-        allCauses = causes;
-        return this;
+        this.causes = Arrays.asList(causes);
     }
 
     public @Nonnull Result getResult() {
@@ -82,7 +61,7 @@ public final class FlowInterruptedException extends InterruptedException {
     }
 
     public @Nonnull List<CauseOfInterruption> getCauses() {
-        return allCauses;
+        return causes;
     }
 
     /**
@@ -91,8 +70,8 @@ public final class FlowInterruptedException extends InterruptedException {
      * @param listener
      */
     public void handle(Run<?,?> run, TaskListener listener) {
-        run.addAction(new InterruptedBuildAction(allCauses));
-        for (CauseOfInterruption cause : allCauses) {
+        run.addAction(new InterruptedBuildAction(causes));
+        for (CauseOfInterruption cause : causes) {
             cause.print(listener);
         }
     }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -68,7 +68,7 @@ public abstract class DefaultStepContext extends StepContext {
         if (key == EnvVars.class) {
             Run<?,?> run = get(Run.class);
             EnvironmentAction a = run.getAction(EnvironmentAction.class);
-            EnvVars env = a != null ? a.getEnvironment() : getEnvironment(run, get(TaskListener.class));
+            EnvVars env = a != null ? a.getEnvironment() : run.getEnvironment(get(TaskListener.class));
             if (value != null) {
                 env = new EnvVars(env);
                 env.putAll((EnvVars) value); // context overrides take precedence over user settings
@@ -148,29 +148,5 @@ public abstract class DefaultStepContext extends StepContext {
      * Finds the associated node.
      */
     protected abstract @Nonnull FlowNode getNode() throws IOException;
-
-    /**
-     * Temporary replacement for broken {@link Run#getEnvironment(TaskListener)}.
-     * TODO 1.591+ replace with standard version
-     */
-    public static EnvVars getEnvironment(Run<?,?> run, TaskListener listener) throws IOException, InterruptedException {
-        EnvVars env = run.getParent().getEnvironment(null, listener);
-        env.putAll(run.getCharacteristicEnvVars());
-        for (EnvironmentContributor ec : EnvironmentContributor.all().reverseView()) {
-            if (ec instanceof CoreEnvironmentContributor) {
-                env.put("BUILD_DISPLAY_NAME", run.getDisplayName());
-                Jenkins j = Jenkins.getInstance();
-                if (j != null) {
-                    String rootUrl = j.getRootUrl();
-                    if (rootUrl != null) {
-                        env.put("BUILD_URL", rootUrl + run.getUrl());
-                    }
-                }
-            } else {
-                ec.buildEnvironmentFor(run, env, listener);
-            }
-        }
-        return env;
-    }
 
 }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
@@ -30,11 +30,13 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Node;
+import hudson.util.FormValidation;
 import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -86,6 +88,7 @@ public final class ExecutorStep extends AbstractStepImpl {
             return true;
         }
 
+        // TODO copied from AbstractProjectDescriptor
         public AutoCompletionCandidates doAutoCompleteLabel(@QueryParameter String value) {
             AutoCompletionCandidates c = new AutoCompletionCandidates();
             Jenkins j = Jenkins.getInstance();
@@ -98,7 +101,10 @@ public final class ExecutorStep extends AbstractStepImpl {
             }
             return c;
         }
-        // proper doCheckValue also requires API requested above
+
+        public FormValidation doCheckLabel(@QueryParameter String value) {
+            return AbstractProject.AbstractProjectDescriptor.validateLabelExpression(value, /* LabelValidator does not support Job */null);
+        }
 
         @SuppressWarnings("unchecked")
         @Override

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -302,7 +302,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return ACL.SYSTEM; // TODO should pick up credentials from configuring user or something
         }
 
-        /* TODO 1.592+: @Override */ public Authentication getDefaultAuthentication(Queue.Item item) {
+        @Override public Authentication getDefaultAuthentication(Queue.Item item) {
             return getDefaultAuthentication();
         }
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
@@ -69,7 +69,7 @@ public class StageStepExecution extends AbstractStepExecutionImpl {
     private static XmlFile getConfigFile() throws IOException {
         Jenkins j = Jenkins.getInstance();
         if (j == null) {
-            throw new IOException("Jenkins is not running");
+            throw new IOException("Jenkins is not running"); // do not use Jenkins.getActiveInstance() as that is an ISE
         }
         return new XmlFile(new File(j.getRootDir(), StageStep.class.getName() + ".xml"));
     }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
@@ -239,7 +239,7 @@ public class StageStepExecution extends AbstractStepExecutionImpl {
     /**
      * Records that a flow was canceled while waiting in a stage step because a newer flow entered that stage instead.
      */
-    public static final class CanceledCause extends CauseOfInterruption implements Serializable {
+    public static final class CanceledCause extends CauseOfInterruption {
 
         private static final long serialVersionUID = 1;
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerCancelledCause.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerCancelledCause.java
@@ -9,7 +9,7 @@ import jenkins.model.CauseOfInterruption;
  * TODO: real summary.jelly
  * @author Kohsuke Kawaguchi
  */
-public class BuildTriggerCancelledCause extends CauseOfInterruption implements Serializable {
+public class BuildTriggerCancelledCause extends CauseOfInterruption {
 
     private static final long serialVersionUID = 1;
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -40,11 +40,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     public boolean start() throws Exception {
         String job = step.getJob();
         listener.getLogger().println("Starting building project: " + job);
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins == null) {
-            throw new IllegalStateException("Jenkins is not running");
-        }
-        final ParameterizedJobMixIn.ParameterizedJob project = jenkins.getItem(job, invokingRun.getParent(), ParameterizedJobMixIn.ParameterizedJob.class);
+        final ParameterizedJobMixIn.ParameterizedJob project = Jenkins.getActiveInstance().getItem(job, invokingRun.getParent(), ParameterizedJobMixIn.ParameterizedJob.class);
         if (project == null) {
             throw new AbortException("No parameterized job named " + job + " found");
         }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -60,13 +60,7 @@ public final class RunWrapper implements Serializable {
      * The result is also not cached, since we want to stop allowing access to a build after it has been deleted.
      */
     public @CheckForNull Run<?,?> getRawBuild() {
-        try {
-            return Run.fromExternalizableId(externalizableId);
-        } catch (IllegalArgumentException x) {
-            // TODO 1.588+ fromExternalizableId will already return null when appropriate if the build has been deleted after restart
-            // (probably preferable to have a null var and produce an NPE somewhere than to break whole flow loading due to this normal condition)
-            return null;
-        }
+        return Run.fromExternalizableId(externalizableId);
     }
 
     private @Nonnull Run<?,?> build() throws AbortException {

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/Rejection.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/Rejection.java
@@ -9,7 +9,7 @@ import org.kohsuke.stapler.export.Exported;
 /**
  * Indicates that the input step was rejected by the user.
  */
-public final class Rejection extends CauseOfInterruption implements Serializable {
+public final class Rejection extends CauseOfInterruption {
 
     private static final long serialVersionUID = 1;
 


### PR DESCRIPTION
Various new APIs can be used, and workarounds removed, once we move to the next LTS baseline. Avoids the need to keep this kind of changes in feature PRs like #37.

@reviewbybees