### PR TITLE
[JENKINS-26085] Handle empty credentialsId

### DIFF
--- a/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/GitStep.java
+++ b/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/GitStep.java
@@ -90,7 +90,7 @@ public final class GitStep extends SCMStep {
     }
 
     @DataBoundSetter public void setCredentialsId(String credentialsId) {
-        this.credentialsId = credentialsId;
+        this.credentialsId = Util.fixEmpty(credentialsId);
     }
 
     @Override public SCM createSCM() {


### PR DESCRIPTION
Fixes mistake made in #79 which caused the snippet generator to offer

```groovy
git credentialsId: '', url: '…'
```

when no credentials were selected. It should be simply

```groovy
git '…'
```

@reviewbybees