### PR TITLE
Illegal to call Jenkins.getNode(null)

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -180,6 +180,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public Node getLastBuiltOn() {
+            if (label == null) {
+                return null;
+            }
             Jenkins j = Jenkins.getInstance();
             if (j == null) {
                 return null;


### PR DESCRIPTION
Otherwise get [this exception](https://gist.githubusercontent.com/jglick/8bf06c6d002faae48f0f/raw/79da82a92b0dd091b344c6d125a49995941448a5/gistfile1.txt) in 1.607+ due to changes in https://github.com/jenkinsci/jenkins/pull/1596. @reviewbybees