### PR TITLE
Raise precedence of imperative env.VAR

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -618,6 +618,9 @@ public class WorkflowTest extends SingleJobTestBase {
                         + "  semaphore 'env'\n"
                         + "  env.BUILD_TAG=\"${env.BUILD_TAG}2\"\n"
                         + "  sh 'echo tag3=$BUILD_TAG stuff=$STUFF'\n"
+                        + "  env.PATH=\"/opt/stuff/bin:${env.PATH}\"\n"
+                        + "  sh 'echo shell PATH=$PATH'\n"
+                        + "  echo \"groovy PATH=${env.PATH}\""
                         + "}", true));
                 startBuilding();
                 SemaphoreStep.waitForStart("env/1", b);
@@ -633,10 +636,13 @@ public class WorkflowTest extends SingleJobTestBase {
                 story.j.assertLogContains("tag=jenkins-demo-1 PERMACHINE=set", b);
                 story.j.assertLogContains("tag2=custom", b);
                 story.j.assertLogContains("tag3=custom2 stuff=more", b);
+                story.j.assertLogContains("shell PATH=/opt/stuff/bin:", b);
+                story.j.assertLogContains("groovy PATH=/opt/stuff/bin:", b);
                 EnvironmentAction a = b.getAction(EnvironmentAction.class);
                 assertNotNull(a);
                 assertEquals("custom2", a.getEnvironment().get("BUILD_TAG"));
                 assertEquals("more", a.getEnvironment().get("STUFF"));
+                assertNotNull(a.getEnvironment().get("PATH"));
             }
         });
     }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -71,23 +71,8 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
 
     @Override public Object getProperty(String propertyName) {
         try {
-            EnvironmentExpander expander = CpsThread.current().getContextVariable(EnvironmentExpander.class);
-            EnvVars overridden = CpsThread.current().getContextVariable(EnvVars.class);
-            if (overridden != null) {
-                if (expander != null) {
-                    overridden = new EnvVars(overridden);
-                    expander.expand(overridden);
-                }
-                String val = overridden.get(propertyName);
-                if (val != null) {
-                    return val;
-                }
-            }
-            EnvVars environment = getEnvironment();
-            if (expander != null) {
-                expander.expand(environment);
-            }
-            return environment.get(propertyName);
+            CpsThread t = CpsThread.current();
+            return EnvironmentExpander.getEffectiveEnvironment(getEnvironment(), t.getContextVariable(EnvVars.class), t.getContextVariable(EnvironmentExpander.class)).get(propertyName);
         } catch (Exception x) {
             LOGGER.log(Level.WARNING, null, x);
             return null;

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -69,18 +69,8 @@ public abstract class DefaultStepContext extends StepContext {
         if (key == EnvVars.class) {
             Run<?,?> run = get(Run.class);
             EnvironmentAction a = run.getAction(EnvironmentAction.class);
-            EnvVars env = a != null ? a.getEnvironment() : run.getEnvironment(get(TaskListener.class));
-            EnvironmentExpander expander = get(EnvironmentExpander.class);
-            if (value != null || expander != null) {
-                env = new EnvVars(env);
-            }
-            if (value != null) {
-                env.putAll((EnvVars) value); // context overrides take precedence over user settings
-            }
-            if (expander != null) {
-                expander.expand(env);
-            }
-            return key.cast(env);
+            EnvVars customEnvironment = a != null ? a.getEnvironment() : run.getEnvironment(get(TaskListener.class));
+            return key.cast(EnvironmentExpander.getEffectiveEnvironment(customEnvironment, (EnvVars) value, get(EnvironmentExpander.class)));
         } else if (value != null) {
             return value;
         } else if (key == TaskListener.class) {


### PR DESCRIPTION
Docker demo sanity check prior to attempted 1.5 release turned up a regression, which I think was introduced by #41, though possibly by #104. Finally testing this, and also extracting previously duplicated code into a new helper method to make it easier to follow.

Really setting `env.VAR = 'value'` was a poor design to begin with (`withEnv` is better), but it is out there and needs to remain supported.

@reviewbybees