### PR TITLE
Allow specifying any commit to checkout from Git

### DIFF
--- a/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/GitStep.java
+++ b/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/GitStep.java
@@ -94,7 +94,7 @@ public final class GitStep extends SCMStep {
     }
 
     @Override public SCM createSCM() {
-        return new GitSCM(createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec("*/" + branch)), false, Collections.<SubmoduleConfig>emptyList(), null, null, null);
+        return new GitSCM(createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec(branch)), false, Collections.<SubmoduleConfig>emptyList(), null, null, null);
     }
 
     // copied from GitSCM


### PR DESCRIPTION
With Git SCM in a regular job the user can specify a commit hash, but this doesn't work with the `git` step. I guess this change should fix the problem.