### PR TITLE
Allow LauncherDecorator to be passed in a step context

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -132,7 +132,7 @@ public abstract class DefaultStepContext extends StepContext {
         else                    return null;
     }
 
-    private @Nonnull Launcher makeLauncher(@CheckForNull Launcher contextual) throws IOException, InterruptedException {
+    private @CheckForNull Launcher makeLauncher(@CheckForNull Launcher contextual) throws IOException, InterruptedException {
         Launcher launcher = contextual;
         Node n = get(Node.class);
         if (launcher == null) {


### PR DESCRIPTION
For some purposes it is useful to be able to pass in a `LauncherDecorator` as part of the context of a block step, so as to affect how commands are run within that block. This change makes that possible.

(You could already install a global `LauncherDecorator` extension, which will get called by `Node.createLauncher`, via `DefaultStepContext`.)

In the future `CoreWrapperStep` (#37) could make use of this, though `SimpleBuildWrapper` would first need to do something with its `decorateLauncher` method, along the lines of the change in https://github.com/jenkinsci/jenkins/pull/1634, and I am weary of preparing core patches for the moment.

The comment in the `ReadFileStep` constructor talks about contextual `LauncherDecorator`s, though in the context of _enforced_ decoration for security purposes (probably via an `@Extension`), so it is not really applicable here.

As I noted in a comment to https://github.com/jenkinsci/maven-interceptors/pull/4 (and then filed as [JENKINS-21746](https://issues.jenkins-ci.org/browse/JENKINS-21746)), for some purposes just changing `Launcher` parameters might not suffice; we might need to be able to affect other aspects of external processes, such as a socket location for callbacks to the Jenkins slave agent. However this is only known to matter for native Maven projects, not Workflow.

@reviewbybees