### PR TITLE
[JENKINS-27571] Non-link in build sidepanel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.6 (upcoming)
 
+* [JENKINS-27571](https://issues.jenkins-ci.org/browse/JENKINS-27571) Fixed link in build sidepanel.
 * API addition: `LauncherDecorator` can now be used in block-scoped steps, and there is more flexibility in handling exits from durable tasks.
 
 ## 1.5 (Apr 01 2015)

--- a/job/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
+++ b/job/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
@@ -28,7 +28,7 @@
     <l:side-panel>
         <l:tasks>
             <j:set var="buildUrl" value="${h.decompose(request)}"/>
-            <l:task icon="images/24x24/up.png" href="${it.upUrl}" title="${%Back to Project}" contextMenu="false"/>
+            <l:task icon="images/24x24/up.png" href="${rootURL}/${it.parent.url}" title="${%Back to Project}" contextMenu="false"/>
             <l:task icon="images/24x24/search.png" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
             <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/changes" title="${%Changes}"/>
             <p:console-link/>


### PR DESCRIPTION
[JENKINS-27571](https://issues.jenkins-ci.org/browse/JENKINS-27571)

Copying the `getUpUrl` method from `AbstractBuild` seems pointless, since it does nothing special. (Within a request coming from inside a view, `AbstractItem.getUrl` already includes the view in the URL.)

@reviewbybees