### PR TITLE
Stage execute all builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.6 (upcoming)
 
+* Added `discardOldBuilds` option to the `stage` step to disable preemption of older builds.
 * [JENKINS-27571](https://issues.jenkins-ci.org/browse/JENKINS-27571) Fixed link in build sidepanel.
 * API addition: `LauncherDecorator` can now be used in block-scoped steps, and there is more flexibility in handling exits from durable tasks.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -597,6 +597,9 @@ Every SCM push can still trigger a separate build of a quicker earlier stage as 
 Yet each build runs linearly and can even retain a single workspace, avoiding the need to identify and copy artifacts between builds.
 (Even if you dispose of a workspace from an earlier stage, you can retain information about it using simple local variables.)
 
+It is possible to disable the preemption of older builds by setting the option discardOldBuilds to false. When this option is false all
+builds that enter the stage will queue up and get built.
+
 Consult the [Docker demo](demo/README.md) for an example of a flow using multiple `stage`s.
 
 # Loading script text from version control

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStep.java
@@ -35,12 +35,14 @@ import org.kohsuke.stapler.DataBoundSetter;
  * Marks a flow build as entering a gated “stage”, like a stage in a pipeline.
  * Each job has a set of named stages, each of which acts like a semaphore with an initial permit count,
  * but with the special behavior that only one build may be waiting at any time: the newest.
+ * To disable this behavior and have all builds queue up and execute set discardOldBuilds to false.
  * Credit goes to @jtnord for implementing the {@code block} operator in {@code buildflow-extensions}, which inspired this.
  */
 public final class StageStep extends AbstractStepImpl {
 
     public final String name;
     @DataBoundSetter public @CheckForNull Integer concurrency;
+    @DataBoundSetter public boolean discardOldBuilds = true;
 
     @DataBoundConstructor public StageStep(String name) {
         if (name == null || name.isEmpty()) {

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/StageStep/config.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/StageStep/config.jelly
@@ -31,4 +31,7 @@ THE SOFTWARE.
     <f:entry field="concurrency" title="Concurrency">
         <f:number clazz="positive-number"/>
     </f:entry>
+    <f:entry field="discardOldBuilds">
+        <f:checkbox title="Discard old builds?" default="true"/>
+    </f:entry>
 </j:jelly>

--- a/support/src/test/java/org/jenkinsci/plugins/workflow/support/steps/StageStepTest.java
+++ b/support/src/test/java/org/jenkinsci/plugins/workflow/support/steps/StageStepTest.java
@@ -38,11 +38,18 @@ public class StageStepTest {
         StageStep s = new StepConfigTester(r).configRoundTrip(new StageStep("name"));
         assertEquals("name", s.name);
         assertEquals(null, s.concurrency);
+        assertTrue(s.discardOldBuilds);
         s = new StageStep("name");
         s.concurrency = 1;
         s = new StepConfigTester(r).configRoundTrip(s);
         assertEquals("name", s.name);
         assertEquals(Integer.valueOf(1), s.concurrency);
+        assertTrue(s.discardOldBuilds);
+        s = new StageStep("name");
+        s.discardOldBuilds = false;
+        assertFalse(s.discardOldBuilds);
+        s = new StepConfigTester(r).configRoundTrip(s);
+        assertFalse(s.discardOldBuilds);
     }
 
 }


### PR DESCRIPTION
Modified the stage step to have the option to execute all builds that enter the stage (no preemption).

Couldn't come up with a better name than `discardOldBuilds`. 
Suggestion for a better name is welcome :)