### PR TITLE
[JENKINS-28179] Workspace suffix should respect hudon.slaves.WorkspaceList property

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -40,6 +40,7 @@ import hudson.slaves.WorkspaceList;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Properties;
 import javax.inject.Inject;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -91,7 +92,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
             if (baseWorkspace == null) {
                 throw new IOException(node.getDisplayName() + " may be offline");
             }
-            dir = baseWorkspace.withSuffix("@script");
+            dir = getFilePathWithSuffix(baseWorkspace);
         } else { // should not happen, but just in case:
             dir = new FilePath(owner.getRootDir());
         }
@@ -117,6 +118,14 @@ public class CpsScmFlowDefinition extends FlowDefinition {
         CpsFlowExecution exec = new CpsFlowExecution(script, true, owner);
         exec.flowStartNodeActions.add(new WorkspaceActionImpl(dir, null));
         return exec;
+    }
+
+    private FilePath getFilePathWithSuffix(FilePath baseWorkspace) {
+        return baseWorkspace.withSuffix(getFilePathSuffix());
+    }
+
+    private String getFilePathSuffix() {
+        return new Properties().getProperty("hudson.slaves.WorkspaceList");
     }
 
     @Extension public static class DescriptorImpl extends FlowDefinitionDescriptor {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -121,7 +121,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
     }
 
     private FilePath getFilePathWithSuffix(FilePath baseWorkspace) {
-        return baseWorkspace.withSuffix(getFilePathSuffix());
+        return baseWorkspace.withSuffix(getFilePathSuffix() + "script");
     }
 
     private String getFilePathSuffix() {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -125,7 +125,11 @@ public class CpsScmFlowDefinition extends FlowDefinition {
     }
 
     private String getFilePathSuffix() {
-        return new Properties().getProperty("hudson.slaves.WorkspaceList");
+        String defined_suffix = new Properties().getProperty("hudson.slaves.WorkspaceList");
+        if (defined_suffix == null || defined_suffix.equals("")) {
+            defined_suffix = "@";
+        }
+        return defined_suffix;
     }
 
     @Extension public static class DescriptorImpl extends FlowDefinitionDescriptor {

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -125,11 +125,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
     }
 
     private String getFilePathSuffix() {
-        String defined_suffix = new Properties().getProperty("hudson.slaves.WorkspaceList");
-        if (defined_suffix == null || defined_suffix.equals("")) {
-            defined_suffix = "@";
-        }
-        return defined_suffix;
+        return System.getProperty(WorkspaceList.class.getName(), "@");
     }
 
     @Extension public static class DescriptorImpl extends FlowDefinitionDescriptor {


### PR DESCRIPTION
These changes resolve JENKINS-28179 by ensuring the suffix for concurrent builds is generated by using hudson.slaves.WorkspaceList. On the off change this isn't defined or is an empty string, it uses the previous value (@) as the workspace suffix separator. 

https://issues.jenkins-ci.org/browse/JENKINS-28179