### PR TITLE
[JENKINS-28649] Api call with AfterRestartTask throws ExportedBean annotation exception

### DIFF
--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
@@ -33,6 +33,7 @@ import hudson.model.queue.AbstractQueueTask;
 import hudson.model.queue.CauseOfBlockage;
 import java.io.IOException;
 import org.acegisecurity.Authentication;
+import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 /**
@@ -42,7 +43,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 @ExportedBean
 class AfterRestartTask extends AbstractQueueTask implements Queue.FlyweightTask, Queue.TransientTask {
 
-    private final WorkflowRun run;
+    @Exported private final WorkflowRun run;
     
     AfterRestartTask(WorkflowRun run) {
         this.run = run;

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
@@ -33,11 +33,13 @@ import hudson.model.queue.AbstractQueueTask;
 import hudson.model.queue.CauseOfBlockage;
 import java.io.IOException;
 import org.acegisecurity.Authentication;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Represents a {@link WorkflowRun} still running after a Jenkins restart.
  * Could be a {@code ContinuedTask}, though not really necessary since it is a {@link FlyweightTask} which would never be blocked anyway.
  */
+@ExportedBean
 class AfterRestartTask extends AbstractQueueTask implements Queue.FlyweightTask, Queue.TransientTask {
 
     private final WorkflowRun run;


### PR DESCRIPTION
- [ ] functional test using HtmlUnit to retrieve (e.g.) `api/json`
- [X] `AfterRestartTask`
- [ ] `PlaceholderTask`

@reviewbybees