### PR TITLE
[JENKINS-27531] Simplified fix

### DIFF
--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -41,7 +41,6 @@ import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
-import hudson.model.RunMap;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
@@ -55,7 +54,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -363,42 +361,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
     
     private static final Map<String,WorkflowRun> LOADING_RUNS = new HashMap<String,WorkflowRun>();
 
-    /**
-     * Same as {@link Run#getId} except it works before the run has been loaded from disk.
-     * TODO JENKINS-27531 this logic should be handled directly in Run.getId() instead.
-     */
-    private static String getId(WorkflowRun r) {
-        String id = r.getId();
-        Class<?> runIdMigratorC;
-        try {
-            runIdMigratorC = Class.forName("jenkins.model.RunIdMigrator");
-        } catch (ClassNotFoundException x) {
-            // 1.596 or earlier, so the ID is fine.
-            return id;
-        }
-        try {
-            RunMap<WorkflowRun> runMap = r.getParent()._getRuns();
-            Field runIdMigratorF = RunMap.class.getField("runIdMigrator");
-            Object runIdMigratorO = runIdMigratorF.get(runMap);
-            Field idToNumberF = runIdMigratorC.getDeclaredField("idToNumber");
-            idToNumberF.setAccessible(true);
-            Map<String,Integer> idToNumberO = (Map<String,Integer>) idToNumberF.get(runIdMigratorO);
-            int n = r.getNumber();
-            for (Map.Entry<String,Integer> entry : idToNumberO.entrySet()) {
-                if (entry.getValue().equals(n)) {
-                    id = entry.getKey();
-                    LOGGER.log(Level.FINE, "recovered legacy ID {0} for {1}", new Object[] {id, r});
-                    return id;
-                }
-            }
-        } catch (Exception x) {
-            LOGGER.log(Level.WARNING, null, x);
-        }
-        return id;
-    }
-
     private String key() {
-        return getParent().getFullName() + '/' + getId(this);
+        return getParent().getFullName() + '/' + getId();
     }
 
     /** Hack to allow {@link #execution} to use an {@link Owner} referring to this run, even when it has not yet been loaded. */
@@ -603,7 +567,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
                 synchronized (LOADING_RUNS) {
                     candidate = LOADING_RUNS.get(key());
                 }
-                if (candidate != null && candidate.getParent().getFullName().equals(job) && getId(candidate).equals(id)) {
+                if (candidate != null && candidate.getParent().getFullName().equals(job) && candidate.getId().equals(id)) {
                     run = candidate;
                 } else {
                     Jenkins jenkins = Jenkins.getInstance();


### PR DESCRIPTION
Subsumes #162.

It seems that the fix of #157 obviated the hack introduced in #97. From what I can tell, the only reason we needed access to `Run.id` in advance of basic `Run` deserialization being complete was that the `CpsFlowExecution` used to try to call `Owner.get()` based on the `id` during that actual deserialization, rather than later during `WorkflowRun.onLoad`.

I tried to also get rid of the `LOADING_RUNS` hack by commenting out

```java
LOADING_RUNS.put(key(), this);
```

but that produced an error in `WorkflowTest.executorStepRestart`:

```
java.io.IOException: java.util.concurrent.ExecutionException: java.lang.AssertionError: tried to overwrite demo #1 with demo #1
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.getThreadSynchronously(CpsStepContext.java:234)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.doGet(CpsStepContext.java:279)
	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:69)
	at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask$PlaceholderExecutable.run(ExecutorStepExecution.java:413)
	at …
Caused by: java.util.concurrent.ExecutionException: java.lang.AssertionError: tried to overwrite demo #1 with demo #1
	at …
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.getThreadSynchronously(CpsStepContext.java:231)
	... 5 more
Caused by: java.lang.AssertionError: tried to overwrite demo #1 with demo #1
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:472)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:448)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:356)
	at hudson.model.RunMap.getById(RunMap.java:203)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:581)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:591)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.getFlowExecution(CpsStepContext.java:426)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.access$000(CpsStepContext.java:93)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$1.run(CpsStepContext.java:247)
	at …
```

which seems to mean that `CpsStepContext` is still calling `Owner.get` before the build record is loaded. That is probably solvable only by extending `CpsFlowExecution.onLoad` to inject its `owner` into all `CpsStepContext`s, perhaps using a thread-local variable in `loadProgramAsync`, or perhaps using changes in #158 to enumerate all contexts via the set of all executions. Work for another day.

@reviewbybees