### PR TITLE
[JENKINS-29738] TimeoutStep restarts the timeout value when onResume method is invoked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user-visible or major API changes, not internal code cle
 
 ## 1.9 (upcoming)
 
+* [JENKINS-29738](https://issues.jenkins-ci.org/browse/JENKINS-29738): TimeoutStep restarts the timeout value when `onResume` method is invoked
 * [JENKINS-26163](https://issues.jenkins-ci.org/browse/JENKINS-26163): `AbstractStepExecutionImpl.onResume` was not (usually) being called for block-scoped steps, leading to incorrect behavior after Jenkins restart for flows inside `timeout` or `waitUntil`.
 * [JENKINS-26761](https://issues.jenkins-ci.org/browse/JENKINS-26761): `NullPointerException` from Git commit notification requests under unknown circumstances; improved robustness and logging.
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -138,7 +138,6 @@ public class TimeoutStepTest extends Assert {
         });
     }
 
-
     // TODO: timeout inside parallel
 
 }

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -117,10 +117,10 @@ public class TimeoutStepTest extends Assert {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "timeIsConsumed");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
-                        + "  timeout(time: 60, unit: 'SECONDS') {\n"
+                        + "  timeout(time: 20, unit: 'SECONDS') {\n"
                         + "    sleep 10\n"
                         + "    semaphore 'timeIsConsumed'\n"
-                        + "    sleep 50\n"
+                        + "    sleep 10\n"
                         + "  }\n"
                         + "}\n"));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -46,9 +46,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             killer = Timer.get().schedule(new Runnable() {
                 @Override
                 public void run() {
-                    if (!body.isDone()) {
-                        body.cancel(new ExceededTimeout());
-                    }
+                    body.cancel(new ExceededTimeout());
                 }
             }, end - now, step.getUnit());
         } else {
@@ -88,7 +86,10 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
     /**
      * Common cause in this step.
      */
-    private class ExceededTimeout extends CauseOfInterruption {
+    public static final class ExceededTimeout extends CauseOfInterruption {
+
+        private static final long serialVersionUID = 1L;
+
         @Override
         public String getShortDescription() {
             return "Timeout has been exceeded";

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -8,8 +8,6 @@ import java.util.concurrent.TimeUnit;
 import jenkins.model.CauseOfInterruption;
 import jenkins.util.Timer;
 
-import javax.annotation.Nonnull;
-
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -46,7 +44,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
      *
      * @param now Current time in milliseconds.
      */
-    private void setupTimer(@Nonnull final long now) {
+    private void setupTimer(final long now) {
         if (end > now) {
             killer = Timer.get().schedule(new Runnable() {
                 @Override


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-29738

In `TimeoutStep`, the timeout value was initialized when `onResume` was invoked.

For example, in this workflow script:

```
node {
  timeout(time: 60, unit: 'SECONDS') {
    sleep 10
    [Jenkins is restarted] <<<
    sleep 50
  }
}
```

The expected result of this execution is `ABORTED`:

1. first sleep step, 10 seg
1. second sleep step, 50 seg
1. restart process (safeRestart), enough to exceed 60 seg.