### PR TITLE
Minor changes to support checkpoints

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -269,7 +269,7 @@ public class CpsFlowExecution extends FlowExecution {
         this(script, false, owner);
     }
 
-    CpsFlowExecution(String script, boolean sandbox, FlowExecutionOwner owner) throws IOException {
+    protected CpsFlowExecution(String script, boolean sandbox, FlowExecutionOwner owner) throws IOException {
         this.owner = owner;
         this.script = script;
         this.sandbox = sandbox;
@@ -387,9 +387,7 @@ public class CpsFlowExecution extends FlowExecution {
         return iota.incrementAndGet();
     }
 
-    @Override
-    public void onLoad(FlowExecutionOwner owner) throws IOException {
-        this.owner = owner;
+    protected void initializeStorage() throws IOException {
         storage = createStorage();
         synchronized (this) {
             // heads could not be restored in unmarshal, so doing that now:
@@ -407,6 +405,12 @@ public class CpsFlowExecution extends FlowExecution {
             }
             startNodesSerial = null;
         }
+    }
+
+    @Override
+    public void onLoad(FlowExecutionOwner owner) throws IOException {
+        this.owner = owner;
+        initializeStorage();
         try {
             if (!isComplete())
                 loadProgramAsync(getProgramDataFile());

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -184,13 +184,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
             newExecution.addListener(new GraphL());
             completed = new AtomicBoolean();
             logsToCopy = new LinkedHashMap<String,Long>();
-            newExecution.start();
-            
-            // It's only okay to initialise the global once the new FlowExecution
-            // has successfully started.
             execution = newExecution;
+            newExecution.start();
             executionPromise.set(newExecution);
         } catch (Throwable x) {
+            execution = null; // ensures isInProgress returns false
             finish(Result.FAILURE, x);
             executionPromise.setException(x);
             return;


### PR DESCRIPTION
Actually only the patch to `CpsFlowExecution` directly supports checkpoints; the patch to `WorkflowRun` addresses a regression from #149 which I noticed also caused random test failures caught at the same time.

@reviewbybees