### PR TITLE
rename 'Running Steps' to 'Workflow Steps'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 Only noting significant user-visible or major API changes, not internal code cleanups and minor bug fixes.
 
 ## 1.9 (upcoming)
-
+* "Running Steps" action if now called "Workflow Steps" as it will show steps for workflows that have long since completed.
 * [JENKINS-29738](https://issues.jenkins-ci.org/browse/JENKINS-29738): TimeoutStep restarts the timeout value when `onResume` method is invoked
 * [JENKINS-26163](https://issues.jenkins-ci.org/browse/JENKINS-26163): `AbstractStepExecutionImpl.onResume` was not (usually) being called for block-scoped steps, leading to incorrect behavior after Jenkins restart for flows inside `timeout` or `waitUntil`.
 * [JENKINS-26761](https://issues.jenkins-ci.org/browse/JENKINS-26761): `NullPointerException` from Git commit notification requests under unknown circumstances; improved robustness and logging.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -579,7 +579,7 @@ You may also have noticed that we are running `JUnitResultArchiver` several time
 The test results recorded in the build are cumulative.
 
 When you view the log for a build with multiple branches, the output from each will be intermixed.
-It can be useful to click on the _Running Steps_ link on the build’s sidebar.
+It can be useful to click on the _Workflow Steps_ link on the build’s sidebar.
 This will display a tree-table view of all the steps run so far in the build, grouped by logical block, for example `parallel` branch.
 You can click on individual steps and get more details, such as the log output for that step in isolation, the workspace associated with a `node` step, and so on.
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/CpsScmFlowDefinitionTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/CpsScmFlowDefinitionTest.java
@@ -62,7 +62,7 @@ public class CpsScmFlowDefinitionTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsScmFlowDefinition(new SingleFileSCM("flow.groovy", "echo 'hello from SCM'"), "flow.groovy"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        // TODO currently the log text is in Run.log, but not on FlowStartNode/LogAction, so not visible from Running Steps etc.
+        // TODO currently the log text is in Run.log, but not on FlowStartNode/LogAction, so not visible from Workflow Steps etc.
         r.assertLogContains("hello from SCM", b);
         r.assertLogContains("Staging flow.groovy", b);
         FlowGraphWalker w = new FlowGraphWalker(b.getExecution());

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction.java
@@ -45,7 +45,7 @@ public final class FlowGraphTableAction implements Action {
     }
 
     @Override public String getDisplayName() {
-        return "Running Steps";
+        return "Workflow Steps";
     }
 
     @Override public String getUrlName() {

--- a/job/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/index.jelly
+++ b/job/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/index.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-    <l:layout title="${it.run.fullDisplayName} Running Steps">
+    <l:layout title="${it.run.fullDisplayName} Workflow Steps">
         <st:include page="sidepanel.jelly" it="${it.run}"/>
         <l:main-panel>
             <st:include it="${it.flowGraph}" page="ajax"/>


### PR DESCRIPTION
as the action will display all steps that have both run and are running to
call the action "Running steps" is incorrect and at first glance to a user
is incorrect. This changes the name to "Workflow Steps" which is
marginally better.

@reviewbybees