### PR TITLE
Updating baseline to 1.609.2 to pick up JENKINS-28840 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.609.1</version>
+        <version>1.609.2</version>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>


### PR DESCRIPTION
[JENKINS-28840](https://issues.jenkins-ci.org/browse/JENKINS-28840) is a nasty deadlock fixed in 1.609.2. It is known to strike functional tests at random, causing them to hang (and this has happened to me during `release:prepare`). This repository configures Surefire to reruns flaky tests, but it does not help here, because `JenkinsRule` currently stops its three-minute test timer _before_ shutting down Jenkins, which is when the deadlock occurs, so there is no recovery.

@reviewbybees