### PR TITLE
[JENKINS-26942] Stash files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user changes, not internal code cleanups and minor bug f
 
 ## 1.10 (upcoming)
 
+* [JENKINS-26942](https://issues.jenkins-ci.org/browse/JENKINS-26942): added `stash` and `unstash` steps (deprecating `unarchive`).
 * [JENKINS-26135](https://issues.jenkins-ci.org/browse/JENKINS-26135): expand global library functionality to allow predefined variables and even custom DSLs.
 * [JENKINS-29890](https://issues.jenkins-ci.org/browse/JENKINS-29890): `input` step submitter was not being consistently logged.
 * [JENKINS-25879](https://issues.jenkins-ci.org/browse/JENKINS-25879), [JENKINS-29875](https://issues.jenkins-ci.org/browse/JENKINS-29875): New API to run long lived tasks that could block on I/O in a separate thread avoiding to block main CPS VM thread.

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/stash/StashTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/stash/StashTest.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps.stash;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.StashManager;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class StashTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-26942")
+    @Test public void smokes() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+            "  writeFile file: 'subdir/fname', text: 'whatever'\n" +
+            "  writeFile file: 'subdir/other', text: 'more'\n" +
+            "  dir('subdir') {stash 'whatever'}\n" +
+            "}\n" +
+            "node {\n" +
+            "  dir('elsewhere') {\n" +
+            "    unstash 'whatever'\n" +
+            "    echo \"got fname: ${readFile 'fname'} other: ${readFile 'other'}\"\n" +
+            "  }\n" +
+            "  writeFile file: 'at-top', text: 'ignored'\n" +
+            "  stash name: 'from-top', includes: 'elsewhere/', excludes: '**/other'\n" +
+            "  semaphore 'ending'\n" +
+            "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("ending/1", b);
+        assertEquals("{from-top={elsewhere/fname=whatever}, whatever={fname=whatever, other=more}}", StashManager.stashesOf(b).toString());
+        SemaphoreStep.success("ending/1", null);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("got fname: whatever other: more", b);
+        assertEquals("{}", StashManager.stashesOf(b).toString());
+    }
+
+}

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -1,0 +1,200 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.flow;
+
+import hudson.AbortException;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.org.apache.tools.tar.TarInputStream;
+import hudson.util.DirScanner;
+import hudson.util.io.ArchiverFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.ArtifactManager;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.tools.tar.TarEntry;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * Manages per-build stashes of files.
+ * Unlike artifacts managed by {@link ArtifactManager}, stashes:
+ * <ul>
+ * <li>Are expected to be transferred to other workspaces during the build.
+ * <li>Generally are discarded when the build finishes.
+ * <li>Are not exposed as part of the build outside Jenkins, for example via REST.
+ * <li>Are stored in an archive format with a simple name, not necessarily related to filenames.
+ * </ul>
+ */
+public class StashManager {
+
+    /**
+     * Saves a stash of some files from a build.
+     * @param build a build to use as storage
+     * @param name a simple name to assign to the stash (must follow {@link Jenkins#checkGoodName} constraints)
+     * @param workspace a directory to use as a base
+     * @param includes a set of Ant-style file includes, separated by commas; null/blank is allowed as a synonym for {@code **} (i.e., everything)
+     * @param excludes an optional set of Ant-style file excludes
+     */
+    public static void stash(@Nonnull Run<?,?> build, @Nonnull String name, @Nonnull FilePath workspace, @Nonnull TaskListener listener, @CheckForNull String includes, @CheckForNull String excludes) throws IOException, InterruptedException {
+        Jenkins.checkGoodName(name);
+        File storage = storage(build, name);
+        storage.getParentFile().mkdirs();
+        OutputStream os = new FileOutputStream(storage);
+        try {
+            int count = workspace.archive(ArchiverFactory.TARGZ, os, new DirScanner.Glob(Util.fixEmpty(includes) == null ? "**" : includes, excludes));
+            if (count == 0) {
+                throw new AbortException("No files included in stash");
+            }
+            listener.getLogger().println("Stashed " + count + " file(s)");
+        } finally {
+            os.close();
+        }
+    }
+
+    /**
+     * Restores a stash of some files from a build.
+     * @param build a build used as storage
+     * @param name a name passed previously to {@link #stash}
+     * @param workspace a directory to copy into
+     */
+    public static void unstash(@Nonnull Run<?,?> build, @Nonnull String name, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        InputStream is = new FileInputStream(storage(build, name));
+        try {
+            workspace.untarFrom(is, FilePath.TarCompression.GZIP);
+            // currently nothing to print; listener is a placeholder
+        } finally {
+            is.close();
+        }
+    }
+
+    /**
+     * Delete any and all stashes in a build.
+     * @param build a build possibly passed to {@link #stash} in the past
+     */
+    public static void clearAll(@Nonnull Run<?,?> build) throws IOException {
+        Util.deleteRecursive(storage(build));
+    }
+
+    /**
+     * Delete any and all stashes in a build unless told otherwise.
+     * {@link StashBehavior#shouldClearAll} may cancel this.
+     * @param build a build possibly passed to {@link #stash} in the past
+     */
+    public static void maybeClearAll(@Nonnull Run<?,?> build) throws IOException {
+        for (StashBehavior behavior : ExtensionList.lookup(StashBehavior.class)) {
+            if (!behavior.shouldClearAll(build)) {
+                return;
+            }
+        }
+        clearAll(build);
+    }
+
+    /**
+     * Copy any stashes from one build to another.
+     * @param build a build possibly passed to {@link #stash} in the past
+     * @param to a new build
+     */
+    public static void copyAll(@Nonnull Run<?,?> from, @Nonnull Run<?,?> to) throws IOException {
+        File fromStorage = storage(from);
+        if (!fromStorage.isDirectory()) {
+            return;
+        }
+        FileUtils.copyDirectory(fromStorage, storage(to));
+    }
+
+    @Restricted(DoNotUse.class) // currently just for tests
+    public static Map<String,Map<String,String>> stashesOf(@Nonnull Run<?,?> build) throws IOException {
+        Map<String,Map<String,String>> result = new TreeMap<String,Map<String,String>>();
+        File[] kids = storage(build).listFiles();
+        if (kids != null) {
+            for (File kid : kids) {
+                String n = kid.getName();
+                if (n.endsWith(SUFFIX)) {
+                    Map<String,String> unpacked = new TreeMap<String,String>();
+                    result.put(n.substring(0, n.length() - SUFFIX.length()), unpacked);
+                    InputStream is = new FileInputStream(kid);
+                    try {
+                        InputStream wrapped = FilePath.TarCompression.GZIP.extract(is);
+                        TarInputStream tis = new TarInputStream(wrapped);
+                        TarEntry te;
+                        while ((te = tis.getNextEntry()) != null) {
+                            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                            IOUtils.copy(tis, baos);
+                            unpacked.put(te.getName(), baos.toString());
+                        }
+                    } finally {
+                        is.close();
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static @Nonnull File storage(@Nonnull Run<?,?> build) {
+        return new File(build.getRootDir(), "stashes");
+    }
+
+    private static @Nonnull File storage(@Nonnull Run<?,?> build, @Nonnull String name) {
+        return new File(storage(build), name + SUFFIX);
+    }
+
+    private static final String SUFFIX = ".tar.gz";
+
+    private StashManager() {}
+
+    /**
+     * Extension point for customizing behavior of stashes from other plugins.
+     */
+    public static abstract class StashBehavior implements ExtensionPoint {
+
+        /**
+         * Allows the normal clearing behavior to be suppressed.
+         * @param build a build which has finished
+         * @return true (the default) to go ahead and call {@link #clearAll}, false to stop
+         */
+        public boolean shouldClearAll(@Nonnull Run<?,?> build) {
+            return true;
+        }
+
+    }
+
+}

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.flow;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
@@ -73,6 +74,7 @@ public class StashManager {
      * @param includes a set of Ant-style file includes, separated by commas; null/blank is allowed as a synonym for {@code **} (i.e., everything)
      * @param excludes an optional set of Ant-style file excludes
      */
+    @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification="fine if mkdirs returns false")
     public static void stash(@Nonnull Run<?,?> build, @Nonnull String name, @Nonnull FilePath workspace, @Nonnull TaskListener listener, @CheckForNull String includes, @CheckForNull String excludes) throws IOException, InterruptedException {
         Jenkins.checkGoodName(name);
         File storage = storage(build, name);
@@ -141,6 +143,7 @@ public class StashManager {
     }
 
     @Restricted(DoNotUse.class) // currently just for tests
+    @SuppressFBWarnings(value="DM_DEFAULT_ENCODING", justification="test code")
     public static Map<String,Map<String,String>> stashesOf(@Nonnull Run<?,?> build) throws IOException {
         Map<String,Map<String,String>> result = new TreeMap<String,Map<String,String>>();
         File[] kids = storage(build).listFiles();

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -102,7 +102,11 @@ public class StashManager {
      */
     public static void unstash(@Nonnull Run<?,?> build, @Nonnull String name, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException {
         Jenkins.checkGoodName(name);
-        InputStream is = new FileInputStream(storage(build, name));
+        File storage = storage(build, name);
+        if (!storage.isFile()) {
+            throw new AbortException("No such saved stash ‘" + name + "’");
+        }
+        InputStream is = new FileInputStream(storage);
         try {
             workspace.untarFrom(is, FilePath.TarCompression.GZIP);
             // currently nothing to print; listener is a placeholder

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -101,6 +101,7 @@ public class StashManager {
      * @param workspace a directory to copy into
      */
     public static void unstash(@Nonnull Run<?,?> build, @Nonnull String name, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        Jenkins.checkGoodName(name);
         InputStream is = new FileInputStream(storage(build, name));
         try {
             workspace.untarFrom(is, FilePath.TarCompression.GZIP);
@@ -180,7 +181,12 @@ public class StashManager {
     }
 
     private static @Nonnull File storage(@Nonnull Run<?,?> build, @Nonnull String name) {
-        return new File(storage(build), name + SUFFIX);
+        File dir = storage(build);
+        File f = new File(dir, name + SUFFIX);
+        if (!f.getParentFile().equals(dir)) {
+            throw new IllegalArgumentException();
+        }
+        return f;
     }
 
     private static final String SUFFIX = ".tar.gz";

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java
@@ -79,6 +79,9 @@ public class StashManager {
         Jenkins.checkGoodName(name);
         File storage = storage(build, name);
         storage.getParentFile().mkdirs();
+        if (storage.isFile()) {
+            listener.getLogger().println("Warning: overwriting stash ‘" + name + "’");
+        }
         OutputStream os = new FileOutputStream(storage);
         try {
             int count = workspace.archive(ArchiverFactory.TARGZ, os, new DirScanner.Glob(Util.fixEmpty(includes) == null ? "**" : includes, excludes));

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStep.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStep.java
@@ -2,14 +2,11 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.tasks.BuildStep;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Artifact archiving.
- *
- * Could be a throw-away until {@link BuildStep} interop.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStep.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStep.java
@@ -36,6 +36,10 @@ public class ArtifactUnarchiverStep extends AbstractStepImpl {
             return "Copy archived artifacts into the workspace";
         }
 
+        @Override public boolean isAdvanced() {
+            return true;
+        }
+
     }
 
 }

--- a/basic-steps/src/main/resources/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStep/help.html
+++ b/basic-steps/src/main/resources/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStep/help.html
@@ -1,0 +1,6 @@
+<div>
+    Shorthand for:
+<pre><code>
+step([$class: 'ArtifactArchiver', artifacts: '(includes)', excludes: '(excludes)'])
+</code></pre>
+</div>

--- a/basic-steps/src/main/resources/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStep/config.jelly
+++ b/basic-steps/src/main/resources/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStep/config.jelly
@@ -38,5 +38,8 @@ THE SOFTWARE.
         </p>
         <pre>unarchive mapping: ['dir/' : '.']
 sh 'cat dir/file'</pre>
+        <p>
+            Replaced for most purposes by <code>stash</code> and <code>unstash</code>.
+        </p>
     </f:block>
 </j:jelly>

--- a/demo/repo/Jenkinsfile
+++ b/demo/repo/Jenkinsfile
@@ -4,7 +4,7 @@ stage 'Dev'
 node {
     checkout scm
     mvn '-o clean package'
-    archive 'target/x.war'
+    dir('target') {stash name: 'war', includes: 'x.war'}
 }
 
 stage 'QA'
@@ -48,7 +48,7 @@ def runTests(duration) {
 }
 
 def deploy(id) {
-    unarchive mapping: ['target/x.war' : 'x.war']
+    unstash 'war'
     sh "cp x.war /tmp/webapps/${id}.war"
 }
 

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -84,6 +84,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
+import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -449,6 +450,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
             }
         }
         FlowExecutionList.get().unregister(new Owner(this));
+        try {
+            StashManager.maybeClearAll(this);
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
     }
 
     /**

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -453,7 +453,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
         try {
             StashManager.maybeClearAll(this);
         } catch (IOException x) {
-            LOGGER.log(Level.WARNING, null, x);
+            LOGGER.log(Level.WARNING, "failed to clean up stashes from " + this, x);
         }
     }
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps.stash;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.flow.StashManager;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class StashStep extends AbstractStepImpl {
+
+    private final @Nonnull String name;
+    private @CheckForNull String includes;
+    private @CheckForNull String excludes;
+
+    @DataBoundConstructor public StashStep(@Nonnull String name) {
+        Jenkins.checkGoodName(name);
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIncludes() {
+        return includes;
+    }
+
+    @DataBoundSetter public void setIncludes(String includes) {
+        this.includes = Util.fixEmpty(includes);
+    }
+
+    public String getExcludes() {
+        return excludes;
+    }
+
+    @DataBoundSetter public void setExcludes(String excludes) {
+        this.excludes = Util.fixEmpty(excludes);
+    }
+
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+        @Inject private transient StashStep step;
+        @StepContextParameter private transient Run<?,?> build;
+        @StepContextParameter private transient FilePath workspace;
+        @StepContextParameter private transient TaskListener listener;
+
+        @Override protected Void run() throws Exception {
+            StashManager.stash(build, step.name, workspace, listener, step.includes, step.excludes);
+            return null;
+        }
+
+    }
+
+    @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override public String getFunctionName() {
+            return "stash";
+        }
+
+        @Override public String getDisplayName() {
+            return "Stash some files to be used later in the build";
+        }
+
+    }
+
+}

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
@@ -74,6 +74,8 @@ public class StashStep extends AbstractStepImpl {
 
     public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
 
+        private static final long serialVersionUID = 1L;
+
         @Inject private transient StashStep step;
         @StepContextParameter private transient Run<?,?> build;
         @StepContextParameter private transient FilePath workspace;

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep.java
@@ -53,6 +53,8 @@ public class UnstashStep extends AbstractStepImpl {
 
     public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
 
+        private static final long serialVersionUID = 1L;
+
         @Inject private transient UnstashStep step;
         @StepContextParameter private transient Run<?,?> build;
         @StepContextParameter private transient FilePath workspace;

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps.stash;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.flow.StashManager;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class UnstashStep extends AbstractStepImpl {
+
+    private final @Nonnull String name;
+
+    @DataBoundConstructor public UnstashStep(@Nonnull String name) {
+        Jenkins.checkGoodName(name);
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+        @Inject private transient UnstashStep step;
+        @StepContextParameter private transient Run<?,?> build;
+        @StepContextParameter private transient FilePath workspace;
+        @StepContextParameter private transient TaskListener listener;
+
+        @Override protected Void run() throws Exception {
+            StashManager.unstash(build, step.name, workspace, listener);
+            return null;
+        }
+
+    }
+
+    @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override public String getFunctionName() {
+            return "unstash";
+        }
+
+        @Override public String getDisplayName() {
+            return "Restore files previously stashed";
+        }
+
+    }
+
+}

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/config.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/config.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="name" title="Name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="includes" title="Includes">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="excludes" title="Excludes">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-excludes.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-excludes.html
@@ -1,0 +1,3 @@
+<div>
+    Optional set of Ant-style exclude patterns.
+</div>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-includes.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-includes.html
@@ -1,0 +1,7 @@
+<div>
+    Optional set of Ant-style include patterns.
+    If blank, treated like <code>**</code>: all files.
+    The current working directory is the base directory for the saved files,
+    which will later be restored in the same relative locations,
+    so if you want to use a subdirectory wrap this in <code>dir</code>.
+</div>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-name.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-name.html
@@ -1,0 +1,4 @@
+<div>
+    Name of a stash.
+    Should be a simple identifier akin to a job name.
+</div>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help.html
@@ -1,0 +1,4 @@
+<div>
+    Saves a set of files for use later in the same build, generally on another node/workspace.
+    Stashed files are not otherwise available and are generally discarded at the end of the build.
+</div>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/config.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="name" title="Name">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/help-name.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/help-name.html
@@ -1,0 +1,3 @@
+<div>
+    Name of a previously saved stash.
+</div>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/help.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/UnstashStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Restores a set of files previously <code>stash</code>ed into the current workspace.
+</div>


### PR DESCRIPTION
[JENKINS-26942](https://issues.jenkins-ci.org/browse/JENKINS-26942)

A fairly simple solution to the common problem in workflows of needing to save some files temporarily that were created in one node/workspace and get them back later. You could previously do this with `archive`/`unarchive` but the syntax was a little clumsier, and there were unwanted side effects to saving artifacts. (Now `archive` should be used only for deliberately saving artifacts.)

@reviewbybees esp. @jtnord