### PR TITLE
Additional warning from StepDescriptor.advanced

### DIFF
--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -1,0 +1,1 @@
+Snippetizer.this_step_should_not_normally_be_used_in=This step should not normally be used in your script. Consult the inline help for details.

--- a/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -39,7 +39,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import org.apache.commons.httpclient.NameValuePair;
+import org.jenkinsci.plugins.workflow.steps.CatchErrorStep;
 import org.jenkinsci.plugins.workflow.steps.CoreStep;
 import org.jenkinsci.plugins.workflow.steps.EchoStep;
 import org.jenkinsci.plugins.workflow.steps.PwdStep;
@@ -53,7 +56,6 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.jvnet.hudson.test.Email;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -82,7 +84,6 @@ public class SnippetizerTest {
         assertRoundTrip(new CoreStep(aa), "step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: 'x.jar'])");
     }
 
-    @Ignore("TODO until 1.601+ expected:<step[([$class: 'ArtifactArchiver', artifacts: 'x.jar'])]> but was:<step[ <object of type hudson.tasks.ArtifactArchiver>]>")
     @Test public void coreStep2() throws Exception {
         assertRoundTrip(new CoreStep(new ArtifactArchiver("x.jar")), "step([$class: 'ArtifactArchiver', artifacts: 'x.jar'])");
     }
@@ -138,16 +139,7 @@ public class SnippetizerTest {
     }
 
     @Test public void generateSnippet() throws Exception {
-        JenkinsRule.WebClient wc = r.createWebClient();
-        WebRequestSettings wrs = new WebRequestSettings(new URL(r.getURL(), Snippetizer.GENERATE_URL), HttpMethod.POST);
-        List<NameValuePair> params = new ArrayList<NameValuePair>();
-        params.add(new NameValuePair("json", "{'stapler-class':'" + EchoStep.class.getName() + "', 'message':'hello world'}"));
-        // WebClient.addCrumb *replaces* rather than *adds*:
-        params.add(new NameValuePair(r.jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(), r.jenkins.getCrumbIssuer().getCrumb(null)));
-        wrs.setRequestParameters(params);
-        WebResponse response = wc.getPage(wrs).getWebResponse();
-        assertEquals("text/plain", response.getContentType());
-        assertEquals("echo 'hello world'", response.getContentAsString().trim());
+        assertGenerateSnippet("{'stapler-class':'" + EchoStep.class.getName() + "', 'message':'hello world'}", "echo 'hello world'", null);
     }
 
     @Issue("JENKINS-26093")
@@ -158,16 +150,27 @@ public class SnippetizerTest {
         // Really this would be a WorkflowJob, but we cannot depend on that here, and it should not matter since we are just looking for Job:
         FreeStyleProject us = d2.createProject(FreeStyleProject.class, "us");
         ds.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("key", "")));
+        assertGenerateSnippet("{'stapler-class':'" + BuildTriggerStep.class.getName() + "', 'job':'../d1/ds', 'parameter':[{'name':'key', 'value':'stuff'}]}", "build job: '../d1/ds', parameters: [[$class: 'StringParameterValue', name: 'key', value: 'stuff']]", us.getAbsoluteUrl() + "configure");
+    }
+
+    @Test public void generateSnippetAdvancedDeprecated() throws Exception {
+        assertGenerateSnippet("{'stapler-class':'" + CatchErrorStep.class.getName() + "'}", "// " + Messages.Snippetizer_this_step_should_not_normally_be_used_in() + "\ncatchError {\n    // some block\n}", null);
+    }
+
+    private void assertGenerateSnippet(@Nonnull String json, @Nonnull String responseText, @CheckForNull String referer) throws Exception {
         JenkinsRule.WebClient wc = r.createWebClient();
         WebRequestSettings wrs = new WebRequestSettings(new URL(r.getURL(), Snippetizer.GENERATE_URL), HttpMethod.POST);
-        wrs.setAdditionalHeader("Referer", us.getAbsoluteUrl() + "configure");
+        if (referer != null) {
+            wrs.setAdditionalHeader("Referer", referer);
+        }
         List<NameValuePair> params = new ArrayList<NameValuePair>();
-        params.add(new NameValuePair("json", "{'stapler-class':'" + BuildTriggerStep.class.getName() + "', 'job':'../d1/ds', 'parameter':[{'name':'key', 'value':'stuff'}]}"));
+        params.add(new NameValuePair("json", json));
+        // WebClient.addCrumb *replaces* rather than *adds*:
         params.add(new NameValuePair(r.jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(), r.jenkins.getCrumbIssuer().getCrumb(null)));
         wrs.setRequestParameters(params);
         WebResponse response = wc.getPage(wrs).getWebResponse();
         assertEquals("text/plain", response.getContentType());
-        assertEquals("build job: '../d1/ds', parameters: [[$class: 'StringParameterValue', name: 'key', value: 'stuff']]", response.getContentAsString().trim());
+        assertEquals(responseText, response.getContentAsString().trim());
     }
 
 }


### PR DESCRIPTION
Off the top of my head @cyrille-leclerc, @apemberton, and @gregsymons have gotten tripped up on the steps added by `docker-workflow`, which are not intended to be used from your script. Trying harder to guide users away from these.

(Really want a different UI, at least a form validation warning, maybe a checkbox guarding access to these steps, etc. All of those options seem to require more work than I have time for, due to lack of options in `/lib/form`. This is a quick fix in the interim. CC @tfennelly.)

@reviewbybees esp. @jtnord