### PR TITLE
[JENKINS-30122] AbstractSynchronousNonBlockingStepExecution neglected to pick up the build’s authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Only noting significant user changes, not internal code cleanups and minor bug fixes.
 
+## 1.10 (upcoming)
+
+* [JENKINS-30122](https://issues.jenkins-ci.org/browse/JENKINS-30122): regression in usage of the Authorize Project plugin in 1.10-beta-1.
+
 ## 1.10-beta-1 (Aug 21 2015)
 
 * [JENKINS-26942](https://issues.jenkins-ci.org/browse/JENKINS-26942): added `stash` and `unstash` steps (deprecating `unarchive`).

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
@@ -34,7 +34,15 @@ public abstract class AbstractSynchronousNonBlockingStepExecution<T> extends Abs
 
     @Override
     public final boolean start() throws Exception {
-        task = getExecutorService().submit(new StepRunner(this));
+        task = getExecutorService().submit(new Runnable() {
+            @Override public void run() {
+                try {
+                    getContext().onSuccess(AbstractSynchronousNonBlockingStepExecution.this.run());
+                } catch (Exception e) {
+                    getContext().onFailure(e);
+                }
+            }
+        });
         return false;
     }
 
@@ -61,21 +69,4 @@ public abstract class AbstractSynchronousNonBlockingStepExecution<T> extends Abs
         return executorService;
     }
 
-    private static class StepRunner implements Runnable {
-
-        private final AbstractSynchronousNonBlockingStepExecution<?> step;
-
-        public StepRunner(AbstractSynchronousNonBlockingStepExecution<?> step) {
-            this.step = step;
-        }
-
-        @Override
-        public void run() {
-            try {
-                step.getContext().onSuccess(step.run());
-            } catch (Exception e) {
-                step.getContext().onFailure(e);
-            }
-        }
-    }
 }

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.security.ACL;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
@@ -40,6 +41,7 @@ public abstract class AbstractSynchronousNonBlockingStepExecution<T> extends Abs
     public final boolean start() throws Exception {
         final Authentication auth = Jenkins.getAuthentication();
         task = getExecutorService().submit(new Runnable() {
+            @SuppressFBWarnings(value="SE_BAD_FIELD", justification="not serializing anything here")
             @Override public void run() {
                 try {
                     getContext().onSuccess(ACL.impersonate(auth, new NotReallyRoleSensitiveCallable<T, Exception>() {


### PR DESCRIPTION
[JENKINS-30122](https://issues.jenkins-ci.org/browse/JENKINS-30122)

@reviewbybees esp. @amuniz