### PR TITLE
load docs are not correct

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -616,7 +616,6 @@ For some cases you may prefer to explicitly load Groovy script text from some so
 The standard Groovy `evaluate` function can be used, but most likely you will want to load a flow definition from a workspace.
 For this purpose you can use the `load` step, which takes a filename in the workspace and runs it as Groovy source text.
 
-The loaded file can contain statements at top level, which are run immediately.
 That is fine if you only want to use a single executor and workspace, and do not mind hard-coding the slave label in the Jenkins job.
 For more complex cases, though, you want to leave the external script in full control of slave allocation.
 In that case the main script defined in the job can just load and run a closure (block of code to be run later):
@@ -645,9 +644,9 @@ def hello(whom) {
 }
 ```
 
-Note that while it can contain helper functions, the only code at top level is a Groovy `Closure`, which is the return value of the script, and thus of the main script’s `load` step.
+Note that while it can contain helper functions, the only code at top level is a Groovy `Closure`, which can be invoked with a call to `()` just like any other method defined in the function `lib.foo`
 
-The helper script can alternately define functions and return `this`, in which case the result of the `load` step can be used to invoke those functions like object methods.
+The helper script can also define functions and return `this`, in which case the result of the `load` step can be used to invoke those functions like object methods.
 An older version of the [Docker demo](demo/README.md) showed this technique in practice:
 
 ```groovy


### PR DESCRIPTION
@jglick my attempts to follow the original docs by getting a `echo "hello world"` to be called on load failed misserably - which leads me to believe that they are wrong.

I could only get the echo to be called if I did
```
def mylib = load 'mylib`
mylib()
```