### PR TITLE
Temporarily declare Jenkins-Version: 1.609.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.609.2</version>
+        <version>1.609.2</version> <!-- but see Jenkins-Version override below -->
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>
@@ -113,6 +113,21 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin> <!-- TODO remove when 1.609.2 more widely installed -->
+                    <groupId>org.jenkins-ci.tools</groupId>
+                    <artifactId>maven-hpi-plugin</artifactId>
+                    <configuration> <!-- only applies to hpi goal, but if I use <execution> here it tries to run that goal on the parent POM which fails -->
+                        <archive>
+                            <manifestEntries>
+                                <Jenkins-Version>1.609.1</Jenkins-Version>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!-- TODO replace with java.level=6 once we have a better plugin parent POM: -->
             <plugin>


### PR DESCRIPTION
Amends #184. Still building & testing against 1.609.2, but declaring a dependency only on 1.609.1, so the plugins will still be offered in the update center for 1.609.1 users. Desirable until more people have 1.609.2 installed.

(Would be nice to build against 1.609.1 but test against 1.609.2, but I could find no way to do that with Maven: you cannot select different artifact versions for `compile` vs. `test` scope. Deleting some entries from the Surefire classpath and then readding them with a different version might work, but this would cause havoc when running tests in a debugger and source-stepping, etc.)

@reviewbybees