### PR TITLE
[JENKINS-30088] Clean up step display in logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user changes, not internal code cleanups and minor bug f
 
 ## 1.11 (not yet released)
 * [JENKINS-30346](https://issues.jenkins-ci.org/browse/JENKINS-30346): added a cross platform `deleteDir` step to recursively delete a directory and its contents.
+* [JENKINS-30088](https://issues.jenkins-ci.org/browse/JENKINS-30088): Adjust how steps are displayed, to make the appearance cleaner and keep a focus on the DSL
 
 ## 1.10 (Aug 31 2015)
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
@@ -148,14 +148,14 @@ public class WorkflowJobNonRestartingTest extends AbstractCpsFlowTest {
 
         idx = 0;
         for (String msg : new String[] {
-            "Running: Retry the body up to N times : Start",
-            "Running: Retry the body up to N times : Body : Start",
-            "Running: Retry the body up to N times : Body : End",
-            "Running: Retry the body up to N times : Body : Start",
-            "Running: Retry the body up to N times : Body : End",
-            "Running: Retry the body up to N times : Body : Start",
-            "Running: Retry the body up to N times : Body : End",
-            "Running: Retry the body up to N times : End",
+            "[Workflow] Retry the body up to N times : Start",
+            "[Workflow] retry {",
+            "[Workflow] } //retry",
+            "[Workflow] retry {",
+            "[Workflow] } //retry",
+            "[Workflow] retry {",
+            "[Workflow] } //retry",
+            "[Workflow] Retry the body up to N times : End",
         }) {
             idx = log.indexOf(msg, idx + 1);
             assertTrue(msg + " not found", idx != -1);

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -141,6 +141,20 @@ public abstract class FlowNode extends Actionable implements Saveable {
         else            return getTypeDisplayName();
     }
 
+    public String getDisplayFunctionName() {
+        String functionName = getTypeFunctionName();
+        if (functionName == null) {
+            return getDisplayName();
+        } else {
+            LabelAction a = getAction(LabelAction.class);
+            if (a != null) {
+                return functionName + ": " + a.getDisplayName();
+            } else {
+                return functionName;
+            }
+        }
+    }
+
     /**
      * Returns colored orb that represents the current state of this node.
      *
@@ -161,6 +175,19 @@ public abstract class FlowNode extends Actionable implements Saveable {
      * This is used to implement {@link #getDisplayName()} as a fallback in case {@link LabelAction} doesnt exist.
      */
     protected abstract String getTypeDisplayName();
+
+    /**
+     * Gets the function name for this type of node.
+     *
+     * Note that this method should be abstract (suppossed to be implemented in all subclasses), but keeping 
+     * it non-abstract to avoid binary incompatibilities.
+     *
+     * @return the function name or null
+     */
+    @CheckForNull
+    protected /* abstract */ String getTypeFunctionName() {
+        return null;
+    }
 
     /**
      * Returns the URL of this {@link FlowNode}, relative to the context root of Jenkins.

--- a/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -42,6 +42,7 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.export.Exported;
@@ -177,16 +178,19 @@ public abstract class FlowNode extends Actionable implements Saveable {
     protected abstract String getTypeDisplayName();
 
     /**
-     * Gets the function name for this type of node.
+     * Gets a human readable text that may include a {@link StepDescriptor#getFunctionName()}.
+     * It would return "echo" for a flow node linked to an EchoStep or "ws {" for WorkspaceStep.
      *
-     * Note that this method should be abstract (suppossed to be implemented in all subclasses), but keeping 
+     * For StepEndNode it would return "} // step.getFunctionName()".
+     *
+     * Note that this method should be abstract (supposed to be implemented in all subclasses), but keeping
      * it non-abstract to avoid binary incompatibilities.
      *
-     * @return the function name or null
+     * @return the text human-readable representation of the step function name
+     *      or {@link FlowNode#getDisplayName()} by default (if not overriden in subclasses)
      */
-    @CheckForNull
     protected /* abstract */ String getTypeFunctionName() {
-        return null;
+        return getDisplayName();
     }
 
     /**

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -40,6 +40,7 @@ import java.util.Collections;
  * @author Kohsuke Kawaguchi
  */
 public class StepAtomNode extends AtomNode implements StepNode {
+
     private final String descriptorId;
 
     // once we successfully convert descriptorId to a real instance, cache that
@@ -69,5 +70,11 @@ public class StepAtomNode extends AtomNode implements StepNode {
     protected String getTypeDisplayName() {
         StepDescriptor d = getDescriptor();
         return d!=null ? d.getDisplayName() : descriptorId;
+    }
+
+    @Override
+    protected String getTypeFunctionName() {
+        StepDescriptor d = getDescriptor();
+        return d != null ? d.getFunctionName() : descriptorId;
     }
 }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
@@ -38,6 +38,17 @@ public class StepEndNode extends BlockEndNode<StepStartNode> implements StepNode
     }
 
     @Override
+    protected String getTypeFunctionName() {
+        StepDescriptor d = getDescriptor();
+        boolean isBody = getStartNode().isBody();
+        if (isBody) {
+            return "} //" + (d != null ? d.getFunctionName() : getStartNode().getStepName());
+        } else {
+            return getStartNode().getStepName() + " : End";
+        }
+    }
+
+    @Override
     public StepDescriptor getDescriptor() {
         return getStartNode().getDescriptor();
     }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -47,6 +47,16 @@ public class StepStartNode extends BlockStartNode implements StepNode {
         return getStepName() + (isBody() ?" : Body":"") + " : Start";
     }
 
+    @Override
+    protected String getTypeFunctionName() {
+        StepDescriptor d = getDescriptor();
+        if (isBody()) {
+            return (d != null ? d.getFunctionName() : descriptorId) + " {";
+        } else {
+            return getStepName() + " : Start";
+        }
+    }
+
     public boolean isBody() {
         return getAction(BodyInvocationAction.class)!=null;
     }

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -656,7 +656,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements Q
             }
             node.addAction(new TimingAction());
 
-            logNodeMessage(node, "Running: " + node.getDisplayName());
+            logNodeMessage(node, "Running: " + node.getDisplayFunctionName());
             if (node instanceof FlowEndNode) {
                 finish(((FlowEndNode) node).getResult(), execution.getCauseOfFailure());
             } else {

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowConsoleLogger.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowConsoleLogger.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.job.console;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+
+import hudson.model.BuildListener;
+
+/**
+ * Console logger used to write workflow related metadata in console text.
+ *
+ * It wraps the regular {@link BuildListener} to add a filter that annotates any text line sent to the console through
+ * this logger. It also adds a prefix to the line ([Workflow]).
+ *
+ * Annotated lines will be rendered in a lighter color so they do not interefere with the important part of the log.
+ */
+public class WorkflowConsoleLogger {
+
+    private final BuildListener listener;
+    private final WorkflowMetadataConsoleFilter annotator;
+
+    public WorkflowConsoleLogger(BuildListener listener) {
+        this.listener = listener;
+        this.annotator = new WorkflowMetadataConsoleFilter(listener.getLogger());
+    }
+
+    /**
+     * Provides access to the wrapped listener logger.
+     * @return the logger print stream
+     */
+    public PrintStream getLogger() {
+        return listener.getLogger();
+    }
+
+    /**
+     * Sends an annotated log message to the console after adding the prefix [Workflow].
+     * @param message the message to wrap and annotate.
+     */
+    public void log(String message) {
+        logAnnot(WorkflowRunConsoleNote.CONSOLE_NOTE_PREFIX, message);
+    }
+
+    private void logAnnot(String prefix, String message) {
+        byte[] msg = String.format("%s%s%n", prefix, message).getBytes(Charset.defaultCharset());
+        try {
+            annotator.eol(msg, msg.length);
+        } catch (IOException e) {
+            listener.getLogger().println("Problem with writing into console log: " + e.getMessage());
+        }
+    }
+}

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowMetadataConsoleFilter.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowMetadataConsoleFilter.java
@@ -24,39 +24,32 @@
 
 package org.jenkinsci.plugins.workflow.job.console;
 
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import java.io.IOException;
+import java.io.OutputStream;
 
-import hudson.MarkupText;
-import hudson.console.ConsoleAnnotator;
-import hudson.console.ConsoleNote;
-import hudson.model.Run;
+import hudson.console.LineTransformationOutputStream;
 
 /**
- * Console note for Workflow metadata specific messages.
- * See {@link WorkflowConsoleLogger} for more information.
+ * It transforms workflow metadata log messages through {@link WorkflowRunConsoleNote}.
  */
-public class WorkflowRunConsoleNote extends ConsoleNote<Run<?, ?>> {
+public class WorkflowMetadataConsoleFilter extends LineTransformationOutputStream {
 
-    /**
-     * Prefix used in metadata lines.
-     */
-    public static final String CONSOLE_NOTE_PREFIX = "[Workflow] ";
+    private final OutputStream out;
 
-    /**
-     * CSS color selector.
-     */
-    private static final String TEXT_COLOR = "9A9999";
-
-    @Override
-    public ConsoleAnnotator<Run<?,?>> annotate(Run<?, ?> context, MarkupText text, int charPos) {
-        if (context instanceof WorkflowRun) {
-            if (text.getText().startsWith(CONSOLE_NOTE_PREFIX)) {
-                text.addMarkup(0, text.length(), "<span style=\"color:#"+ TEXT_COLOR +"\">", "</span>");
-            }
-        }
-        return null;
+    public WorkflowMetadataConsoleFilter(OutputStream out) {
+        this.out = out;
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    protected void eol(byte[] b, int len) throws IOException {
+        new WorkflowRunConsoleNote().encodeTo(out);
+        out.write(b, 0, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        out.close();
+    }
 
 }

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowRunConsoleNote.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowRunConsoleNote.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.workflow.job.console;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+import hudson.model.Run;
+
+public class WorkflowRunConsoleNote extends ConsoleNote<Run<?, ?>> {
+
+    @Override
+    public ConsoleAnnotator<Run<?,?>> annotate(Run<?, ?> context, MarkupText text, int charPos) {
+        if (context instanceof WorkflowRun) {
+            // TODO
+        }
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        public String getDisplayName() {
+            return "Workflow Console Note";
+        }
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowRunConsoleNote.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/console/WorkflowRunConsoleNote.java
@@ -47,11 +47,14 @@ public class WorkflowRunConsoleNote extends ConsoleNote<Run<?, ?>> {
      */
     private static final String TEXT_COLOR = "9A9999";
 
+    private static final String START_NOTE = "<span style=\"color:#"+ TEXT_COLOR +"\">";
+    private static final String END_NOTE = "</span>";
+
     @Override
     public ConsoleAnnotator<Run<?,?>> annotate(Run<?, ?> context, MarkupText text, int charPos) {
         if (context instanceof WorkflowRun) {
             if (text.getText().startsWith(CONSOLE_NOTE_PREFIX)) {
-                text.addMarkup(0, text.length(), "<span style=\"color:#"+ TEXT_COLOR +"\">", "</span>");
+                text.addMarkup(0, text.length(), START_NOTE, END_NOTE);
             }
         }
         return null;


### PR DESCRIPTION
[JENKINS-30088](https://issues.jenkins-ci.org/browse/JENKINS-30088)
Note that the first point described in the JIRA issue is fixed in https://github.com/jenkinsci/workflow-plugin/pull/211 which is more focused on the Snippet Generator clean up.

A screenshot showing how the logs are printed given the following script:

```
node {
  echo 'Starting!'
  stage 'Checkout'
  git 'https://github.com/amuniz/maven-helloworld.git'
  stage 'Building'
  sh 'uname -a'
  ws('other-ws') {
    echo 'This is another workspace'
  }
  stage 'Release'
  echo 'Releasing...'
}
```

<img width="1057" alt="workflow-logs" src="https://cloud.githubusercontent.com/assets/1017585/10145771/6d2b0ff4-6625-11e5-81b1-f24d8b58b0d4.png">

I'm not an UX expert, so any comment on how _metadata_ log lines and the _rest of the build log_ could live better together will be welcome!

@reviewbybees 