### PR TITLE
Add build number link info in BuildTriggerStepExecution

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -67,7 +67,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         if (f == null) {
             throw new AbortException("Failed to trigger build of " + project.getFullName());
         }
-        Run r = (Run) f.waitForStart();
+        Run r = (Run) f.getStartCondition().get();
         listener.getLogger().println("Starting building project: " + HyperlinkNote.encodeTo('/' + r.getUrl(), r.getFullDisplayName()));
         if (step.getWait()) {
             return false;

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import com.google.inject.Inject;
 import hudson.AbortException;
+import hudson.console.HyperlinkNote;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
@@ -39,7 +40,6 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     @Override
     public boolean start() throws Exception {
         String job = step.getJob();
-        listener.getLogger().println("Starting building project: " + job);
         final ParameterizedJobMixIn.ParameterizedJob project = Jenkins.getActiveInstance().getItem(job, invokingRun.getParent(), ParameterizedJobMixIn.ParameterizedJob.class);
         if (project == null) {
             throw new AbortException("No parameterized job named " + job + " found");
@@ -67,6 +67,8 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         if (f == null) {
             throw new AbortException("Failed to trigger build of " + project.getFullName());
         }
+        Run r = (Run) f.waitForStart();
+        listener.getLogger().println("Starting building project: " + HyperlinkNote.encodeTo('/' + r.getUrl(), r.getFullDisplayName()));
         if (step.getWait()) {
             return false;
         } else {


### PR DESCRIPTION
This push will provide a clear log for BuildTriggerStep.

Before: Starting building project: test

After fix: Starting building project: test #7 //(here test # 7 is a hyper link that means we can directly go to the build instead of go to the job firstly then investigate which is been triggered by this step)
![demo](https://cloud.githubusercontent.com/assets/1169277/10221594/a72dbf7c-684f-11e5-8344-145633ca3216.PNG)
