### PR TITLE
Add build number link info in BuildTriggerStepExecution

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import com.google.inject.Inject;
 import hudson.AbortException;
+import hudson.console.HyperlinkNote;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
@@ -39,7 +40,6 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     @Override
     public boolean start() throws Exception {
         String job = step.getJob();
-        listener.getLogger().println("Starting building project: " + job);
         final ParameterizedJobMixIn.ParameterizedJob project = Jenkins.getActiveInstance().getItem(job, invokingRun.getParent(), ParameterizedJobMixIn.ParameterizedJob.class);
         if (project == null) {
             throw new AbortException("No parameterized job named " + job + " found");
@@ -67,6 +67,8 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         if (f == null) {
             throw new AbortException("Failed to trigger build of " + project.getFullName());
         }
+        Run r = (Run) f.getStartCondition().get();
+        listener.getLogger().println("Starting building project: " + HyperlinkNote.encodeTo('/' + r.getUrl(), r.getFullDisplayName()));
         if (step.getWait()) {
             return false;
         } else {


### PR DESCRIPTION
Add build number link for build job step.

Before patch: Starting building project: test

After patch: Starting building project: test #15

For detail, can ref the attachment.
![demo](https://cloud.githubusercontent.com/assets/1169277/10231390/bf365362-6882-11e5-8339-4cc6e6806dba.PNG)
