### PR TITLE
AnsiColorPlugin 0.4.1 is not compatible

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -66,7 +66,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [X] `XvfbBuildWrapper` (`xvfb`): supported as of 1.1.0-beta-1
 - [X] `GCloudBuildWrapper` (`gcloud-sdk`): scheduled to be supported as of 0.0.2
 - [X] `NpmPackagesBuildWrapper` (`nodejs`): scheduled to be supported as of 0.3
-- [X] `AnsiColorBuildWrapper` (`ansicolor`): scheduled to be supported as of 0.4.1
+- [ ] `AnsiColorBuildWrapper` (`ansicolor`): scheduled to be supported as of 0.4.2
 - [ ] `CustomToolInstallWrapper` (`custom-tools-plugin`): [JENKINS-30680](https://issues.jenkins-ci.org/browse/JENKINS-30680) 
 
 ## Triggers


### PR DESCRIPTION
The pull request was not merged in time for the 0.4.1 release. I assume it will be in 0.4.2, since it is now in master.