### PR TITLE
Fix demo image assembly

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -10,10 +10,11 @@ RUN ln -sv /usr/local/apache-maven-$MAVEN_VERSION /usr/local/maven
 # install Jetty
 WORKDIR /opt
 # jetty package is still 8
-ENV JETTY_VERSION 9.2.11.v20150529
+ENV JETTY_VERSION 9.2.12.v20150709
 RUN wget -O - "http://mirrors.ibiblio.org/eclipse/jetty/$JETTY_VERSION/dist/jetty-distribution-$JETTY_VERSION.tar.gz" | tar xvfz -
 RUN ln -sv jetty-distribution-$JETTY_VERSION jetty
 RUN cd /tmp; ln -s /opt/jetty/webapps
+RUN chown -R jenkins /opt/jetty/logs
 
 ENV JENKINS_UC http://jenkins-updates.cloudbees.com
 COPY workflow-version.txt plugins.txt /tmp/files/

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -15,6 +15,7 @@ RUN wget -O - "http://mirrors.ibiblio.org/eclipse/jetty/$JETTY_VERSION/dist/jett
 RUN ln -sv jetty-distribution-$JETTY_VERSION jetty
 RUN cd /tmp; ln -s /opt/jetty/webapps
 RUN chown -R jenkins /opt/jetty/logs
+RUN chown -R jenkins /opt/jetty/webapps
 
 ENV JENKINS_UC http://jenkins-updates.cloudbees.com
 COPY workflow-version.txt plugins.txt /tmp/files/


### PR DESCRIPTION
- [x] Update Jetty version. Original no longer available for download.
- [x] Set ownership on the jetty logs dir for user jenkins. Otherwise, results in write failures when demo is running.
- [x] Set ownership on the jetty/webapps dir for user jenkins.

I also see `hudson.model.Computer$TerminationRequest` exceptions while the build is running ([see gist](https://gist.github.com/tfennelly/252efe7f9d34b90e14b5) ). These same exceptions happen when I pull and run the latest published image (so is not a regression). The demo runs fine.

I did not update the demo to use v1.10.1 of the workflow plugins, or to use the 1.625.1 jenkins docker image, but I did change and test it locally and it worked fine.