### PR TITLE
[JENKINS-30798] SCMBinder was calling the wrong overload of SCMSource.fetch

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.cps;
 
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Action;
@@ -40,7 +41,6 @@ import hudson.slaves.WorkspaceList;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Properties;
 import javax.inject.Inject;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -110,6 +110,9 @@ public class CpsScmFlowDefinition extends FlowDefinition {
             FilePath scriptFile = dir.child(scriptPath);
             if (!scriptFile.absolutize().getRemote().replace('\\', '/').startsWith(dir.absolutize().getRemote().replace('\\', '/') + '/')) { // TODO JENKINS-26838
                 throw new IOException(scriptFile + " is not inside " + dir);
+            }
+            if (!scriptFile.exists()) {
+                throw new AbortException(scriptFile + " not found");
             }
             script = scriptFile.readToString();
         } finally {


### PR DESCRIPTION
[JENKINS-30798](https://issues.jenkins-ci.org/browse/JENKINS-30798)

Essentially the same change as #231 but with some additional robustness fixes, and more clearly showing what is being fixed here.

@reviewbybees esp. @recena