### PR TITLE
ace-editor and jquery-detached have been updated

### DIFF
--- a/cps/pom.xml
+++ b/cps/pom.xml
@@ -80,12 +80,12 @@
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>jquery-detached</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>ace-editor</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
These dependencies are available in the update center: `ace-editor:1.0.1` and `jquery-detached:1.1.1`

@reviewbybees especially @tfennelly 
