### PR TITLE
[JENKINS-31391] - EXECUTOR_NUMBER passed inside node{} block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Only noting significant user changes, not internal code cleanups and minor bug f
 
 ## 1.11 (upcoming)
 
+* [JENKINS-31391](https://issues.jenkins-ci.org/browse/JENKINS-31391): pass `EXECUTOR_NUMBER` into `node {}`.
 * [JENKINS-28769](https://issues.jenkins-ci.org/browse/JENKINS-28769): syntax highlighting, example scripts, and basic code snippets for Workflow scripts in the browser.
 * When running the `build` step, the upstream log should now show a link to the downstream build.
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -43,7 +43,7 @@ public class EnvWorkflowTest {
      *
      * @throws Exception
      */
-    @Test public void areAvailable() throws Exception {
+    @Test public void isNodeNameAvailable() throws Exception {
         r.createSlave("node-test", null, null);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
 
@@ -58,6 +58,30 @@ public class EnvWorkflowTest {
             "node('node-test') {\n" +
             "  echo \"My name on a slave is ${env.NODE_NAME}\"\n" +
             "}\n"
+        ));
+        r.assertLogContains("My name on a slave is node-test", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
+    /**
+     * Verifies if EXECUTOR_NUMBER environment variable is available on a slave node and on master.
+     *
+     * @throws Exception
+     */
+    @Test public void isExecutorNumberAvailable() throws Exception {
+        r.createSlave("node-test", null, null);
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('master') {\n" +
+                        "  echo \"My name on master is ${env.EXECUTOR_NUMBER}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My name on master is master", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('node-test') {\n" +
+                        "  echo \"My name on a slave is ${env.EXECUTOR_NUMBER}\"\n" +
+                        "}\n"
         ));
         r.assertLogContains("My name on a slave is node-test", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }

--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/EnvActionImpl/Binder/help.jelly
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/EnvActionImpl/Binder/help.jelly
@@ -31,7 +31,6 @@ node {
         The following variables are currently unavailable inside a workflow script:
     </p>
     <ul>
-        <li><code>EXECUTOR_NUMBER</code></li>
         <li><code>NODE_LABELS</code></li>
         <li><code>WORKSPACE</code></li>
         <li>SCM-specific variables such as <code>SVN_REVISION</code></li>

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -410,8 +410,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         env.put(COOKIE_VAR, cookie);
                         if (exec.getOwner() instanceof MasterComputer) {
                             env.put("NODE_NAME", "master");
+                            env.put("EXECUTOR_NUMBER", "master");
                         } else {
                             env.put("NODE_NAME", label);
+                            env.put("EXECUTOR_NUMBER", label);
                         }
 
                         synchronized (runningTasks) {


### PR DESCRIPTION
- [x] Source code changes
- [x] Inline documentation about ENV variables
- [x] Passing functional test that runs my name is script
- [x] Update CHANGES.md

Follows the same path as https://github.com/jenkinsci/workflow-plugin/pull/145, just for EXECUTOR_NUMBER.

Implements https://issues.jenkins-ci.org/browse/JENKINS-31391