### PR TITLE
Add getting-started pages for branch sources

### DIFF
--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
@@ -23,8 +23,8 @@
  -->
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
-  This file should contain a valid 
-  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
-  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+    Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
+    This file should contain a valid 
+    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
 </st:compress>

--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
@@ -23,8 +23,8 @@
  -->
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-    Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
-    This file should contain a valid 
-    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
-    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+  Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
+  This file should contain a valid 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
 </st:compress>

--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started.jelly
@@ -1,0 +1,30 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2016, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
+  This file should contain a valid 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+</st:compress>

--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
@@ -1,0 +1,30 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2016, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  Pipeline Multibranch projects recognize and build repositories with a file named <code>Jenkinsfile</code> in branches of the repository.
+  This file should contain a valid
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+</st:compress>

--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
@@ -23,8 +23,8 @@
  -->
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  Pipeline Multibranch projects recognize and build repositories with a file named <code>Jenkinsfile</code> in branches of the repository.
-  This file should contain a valid
-  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
-  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+    Pipeline Multibranch projects recognize and build repositories with a file named <code>Jenkinsfile</code> in branches of the repository.
+    This file should contain a valid
+    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
 </st:compress>

--- a/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
+++ b/multibranch/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started.jelly
@@ -23,8 +23,8 @@
  -->
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-    Pipeline Multibranch projects recognize and build repositories with a file named <code>Jenkinsfile</code> in branches of the repository.
-    This file should contain a valid
-    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
-    <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+  Pipeline Multibranch projects recognize and build repositories with a file named <code>Jenkinsfile</code> in branches of the repository.
+  This file should contain a valid
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
 </st:compress>


### PR DESCRIPTION
@reviewbybees 

This will PR can happen independently, but will result in integration with improved information pages in the circumstance no items are present in multibranch & organization folders: https://github.com/jenkinsci/branch-api-plugin/pull/17
