### PR TITLE
Update jetty version for demo

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -10,7 +10,7 @@ RUN ln -sv /usr/local/apache-maven-$MAVEN_VERSION /usr/local/maven
 # install Jetty
 WORKDIR /opt
 # jetty package is still 8
-ENV JETTY_VERSION 9.2.12.v20150709
+ENV JETTY_VERSION 9.2.13.v20150730
 RUN wget -O - "http://mirrors.ibiblio.org/eclipse/jetty/$JETTY_VERSION/dist/jetty-distribution-$JETTY_VERSION.tar.gz" | tar xvfz -
 RUN ln -sv jetty-distribution-$JETTY_VERSION jetty
 RUN cd /tmp; ln -s /opt/jetty/webapps


### PR DESCRIPTION
`9.2.12.v20150709` is not available anymore on ibiblio (404 on `http://mirrors.ibiblio.org/eclipse/jetty/9.2.12.v20150709`)

@reviewbybees 