### PR TITLE
[Fixed JENKINS-31585] Make workflow editor (ACE) resizable.

### DIFF
--- a/cps/gulpfile.js
+++ b/cps/gulpfile.js
@@ -8,5 +8,5 @@ var builder = require('jenkins-js-builder');
 // See https://github.com/tfennelly/jenkins-js-builder#bundling
 //
 builder.bundle('src/main/js/workflow-editor.js')
-    .withExternalModuleMapping('jquery-detached', 'jquery-detached:jquery2')
+    .withExternalModuleMapping('jqueryui-detached', 'jquery-detached:jqueryui1')
     .inDir('target/generated-resources/adjuncts/org/jenkinsci/plugins/workflow/cps');

--- a/cps/package.json
+++ b/cps/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "jenkins-js-modules": "1.3.0",
-    "jquery-detached": "^2.1.4-v2",
+    "jqueryui-detached": "^1.11.4-v9",
     "window-handle": "0.0.6"
   }
 }

--- a/cps/src/main/js/samples.js
+++ b/cps/src/main/js/samples.js
@@ -1,7 +1,7 @@
 var samples = [];
 
 exports.addSamplesWidget = function(editor) {
-    var $ = require('jquery-detached').getJQuery();
+    var $ = require('jqueryui-detached').getJQueryUI();
 
     if ($('#workflow-editor-wrapper .samples').length) {
         // Already there.

--- a/cps/src/main/js/workflow-editor.js
+++ b/cps/src/main/js/workflow-editor.js
@@ -1,4 +1,4 @@
-var $ = require('jquery-detached').getJQuery();
+var $ = require('jqueryui-detached').getJQueryUI();
 var jenkinsJSModules = require('jenkins-js-modules');
 var wrapper = $('#workflow-editor-wrapper');
 var textarea = $('textarea', wrapper);
@@ -21,7 +21,8 @@ jenkinsJSModules.import('ace-editor:ace-editor-122')
             var editor = this.editor;
             
             // Attach the ACE editor instance to the element. Useful for testing.
-            $('#workflow-editor').get(0).aceEditor = editor;
+            var $wfEditor = $('#workflow-editor');
+            $wfEditor.get(0).aceEditor = editor;
 
             acePack.addPackOverride('snippets/groovy.js', '../workflow-cps/snippets/workflow.js');
 
@@ -33,7 +34,6 @@ jenkinsJSModules.import('ace-editor:ace-editor-122')
                 editor.setTheme("ace/theme/tomorrow");
                 editor.setAutoScrollEditorIntoView(true);
                 editor.setOption("minLines", 20);
-                editor.setOption("maxLines", 20);
                 // enable autocompletion and snippets
                 editor.setOptions({
                     enableBasicAutocompletion: true,
@@ -57,6 +57,19 @@ jenkinsJSModules.import('ace-editor:ace-editor-122')
                 }
                 showSamplesWidget();
             });
+            
+            // Make the editor resizable using jQuery UI resizable (http://api.jqueryui.com/resizable).
+            // ACE Editor doesn't have this as a config option.
+            $wfEditor.wrap('<div class="jquery-ui-1"></div>');
+            $wfEditor.resizable({
+                handles: "s", // Only allow vertical resize off the bottom/south border
+                resize: function() {
+                    editor.resize();
+                }
+            });
+            // Make the bottom border a bit thicker as a visual cue.
+            // May not be enough for some people's taste.
+            $wfEditor.css('border-bottom-width', '0.4em');
         });
     });
 


### PR DESCRIPTION
[JENKINS-31585](https://issues.jenkins-ci.org/browse/JENKINS-31585)

ACE Editor doesn't support drag resize so this PR uses jQuery UI and it's "resizable" function to accomplish it.