### PR TITLE
Update COMPATIBILITY.md; ansicolor is now supported

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -66,7 +66,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [X] `XvfbBuildWrapper` (`xvfb`): supported as of 1.1.0-beta-1
 - [X] `GCloudBuildWrapper` (`gcloud-sdk`): scheduled to be supported as of 0.0.2
 - [X] `NpmPackagesBuildWrapper` (`nodejs`): scheduled to be supported as of 0.3
-- [ ] `AnsiColorBuildWrapper` (`ansicolor`): scheduled to be supported as of 0.4.2
+- [X] `AnsiColorBuildWrapper` (`ansicolor`): supported as of 0.4.2
 - [ ] `CustomToolInstallWrapper` (`custom-tools-plugin`): [JENKINS-30680](https://issues.jenkins-ci.org/browse/JENKINS-30680) 
 - [ ] `PortAllocator` (`port-allocator`): [JENKINS-31449](https://issues.jenkins-ci.org/browse/JENKINS-31449)
 


### PR DESCRIPTION
Just noticed that support for workflows was recently merged so updated the `COMPATIBILITY.md` to reflect that.

https://github.com/dblock/jenkins-ansicolor-plugin/pull/54