### PR TITLE
[JENKINS-31902] Fix of interrupt handling for downstream flows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Only noting significant user changes, not internal code cleanups and minor bug fixes.
 
+## 1.12 (upcoming)
+
+* [JENKINS-31902](https://issues.jenkins-ci.org/browse/JENKINS-31902): interrupting the `build` step failed to interrupt downstream Workflow builds.
+
 ## 1.12-beta-2 (Nov 25 2015)
 
 * [JENKINS-29705](https://issues.jenkins-ci.org/browse/JENKINS-29705): added _Thread Dump_ link to running flow builds for diagnosing problems like hangs.

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildQueueListener.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildQueueListener.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
@@ -13,7 +14,7 @@ public class BuildQueueListener extends QueueListener {
     public void onLeft(Queue.LeftItem li) {
         if(li.isCancelled()){
             for (BuildTriggerAction action : li.getActions(BuildTriggerAction.class)) {
-                action.getStepContext().onFailure(new Exception(String.format("Build %s was cancelled.", li.task.getName())));
+                action.getStepContext().onFailure(new AbortException("Build of " + li.task.getFullDisplayName() + " was cancelled"));
             }
         }
     }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import com.google.inject.Inject;
 import hudson.AbortException;
-import hudson.console.HyperlinkNote;
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
@@ -44,7 +44,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         if (project == null) {
             throw new AbortException("No parameterized job named " + job + " found");
         }
-        listener.getLogger().println("Scheduling project: " + HyperlinkNote.encodeTo('/' + project.getUrl(), project.getFullDisplayName()));
+        listener.getLogger().println("Scheduling project: " + ModelHyperlinkNote.encodeTo(project));
 
         node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
         List<Action> actions = new ArrayList<Action>();
@@ -88,7 +88,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         Queue q = jenkins.getQueue();
 
         // if the build is still in the queue, abort it.
-        // BuildTriggerListener will report the failure, so this method shouldn't call getContext().onFailure()
+        // BuildQueueListener will report the failure, so this method shouldn't call getContext().onFailure()
         for (Queue.Item i : q.getItems()) {
             for (BuildTriggerAction bta : i.getActions(BuildTriggerAction.class)) {
                 if (bta.getStepContext().equals(getContext())) {


### PR DESCRIPTION
[JENKINS-31902](https://issues.jenkins-ci.org/browse/JENKINS-31902)

Also took the opportunity to touch up console log display, which was fairly crude.

@reviewbybees