### PR TITLE
[JENKINS-31086] Add useDefaultExcludes option to stash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Only noting significant user changes, not internal code cleanups and minor bug f
 * [JENKINS-31902](https://issues.jenkins-ci.org/browse/JENKINS-31902): interrupting the `build` step failed to interrupt downstream Workflow builds.
 * [JENKINS-29413](https://issues.jenkins-ci.org/browse/JENKINS-29413): hung build when running the `parallel` step with an empty map.
 * [JENKINS-29881](https://issues.jenkins-ci.org/browse/JENKINS-29881): don't include empty changesets in `WorkflowRun.getChangeSets()`.
+* [JENKINS-31086](https://issues.jenkins-ci.org/browse/JENKINS-31086): Added `useDefaultExcludes` option, defaulting to true, to `stash`. When false, Ant default excludes are not used.
 
 ## 1.12-beta-2 (Nov 25 2015)
 

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
@@ -30,8 +30,6 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
@@ -41,11 +39,15 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 public class StashStep extends AbstractStepImpl {
 
     private final @Nonnull String name;
     private @CheckForNull String includes;
     private @CheckForNull String excludes;
+    private boolean useDefaultExcludes = true;
 
     @DataBoundConstructor public StashStep(@Nonnull String name) {
         Jenkins.checkGoodName(name);
@@ -72,6 +74,14 @@ public class StashStep extends AbstractStepImpl {
         this.excludes = Util.fixEmpty(excludes);
     }
 
+    public boolean isUseDefaultExcludes() {
+        return useDefaultExcludes;
+    }
+
+    @DataBoundSetter public void setUseDefaultExcludes(boolean useDefaultExcludes) {
+        this.useDefaultExcludes = useDefaultExcludes;
+    }
+
     public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
 
         private static final long serialVersionUID = 1L;
@@ -82,7 +92,8 @@ public class StashStep extends AbstractStepImpl {
         @StepContextParameter private transient TaskListener listener;
 
         @Override protected Void run() throws Exception {
-            StashManager.stash(build, step.name, workspace, listener, step.includes, step.excludes);
+            StashManager.stash(build, step.name, workspace, listener, step.includes, step.excludes,
+                    step.useDefaultExcludes);
             return null;
         }
 

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/config.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/config.jelly
@@ -34,4 +34,7 @@ THE SOFTWARE.
     <f:entry field="excludes" title="Excludes">
         <f:textbox/>
     </f:entry>
+    <f:entry field="useDefaultExcludes" title="Use Default Ant Excludes">
+        <f:checkbox default="true" />
+    </f:entry>
 </j:jelly>

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-useDefaultExcludes.html
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help-useDefaultExcludes.html
@@ -1,0 +1,4 @@
+<div>
+    If selected, use the default excludes from Ant - see
+    <a href="http://ant.apache.org/manual/dirtasks.html#defaultexcludes" target="_blank">here</a> for the list.
+</div>


### PR DESCRIPTION
[JENKINS-31086](https://issues.jenkins-ci.org/browse/JENKINS-31086)

Defaults to true, meaning use Ant default excludes for
DirScanner.Glob. If false, don't use the default excludes, to pick up
files like .gitignore etc.

@reviewbybees 