### PR TITLE
[JENKINS-31769] Prevent some problems with hanging sh steps

### DIFF
--- a/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -137,7 +137,10 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
         @Override public void stop(Throwable cause) throws Exception {
             FilePath workspace = getWorkspace();
             if (workspace != null) {
+                listener.getLogger().println("Sending interrupt signal to process");
                 controller.stop(workspace, getContext().get(Launcher.class));
+            } else {
+                listener.getLogger().println("Could not connect to " + node + " to send interrupt signal to process");
             }
         }
 
@@ -185,16 +188,17 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
                 if (exitCode == null) {
                     LOGGER.log(Level.FINE, "still running in {0} on {1}", new Object[] {remote, node});
                 } else {
-                    recurrencePeriod = 0;
                     if (controller.writeLog(workspace, listener.getLogger())) {
                         LOGGER.log(Level.FINE, "last-minute output in {0} on {1}", new Object[] {remote, node});
                     }
-                    controller.cleanup(workspace);
+                    t.set(null); // do not interrupt cleanup
                     if (exitCode == 0) {
                         getContext().onSuccess(exitCode);
                     } else {
                         getContext().onFailure(new AbortException("script returned exit code " + exitCode));
                     }
+                    recurrencePeriod = 0;
+                    controller.cleanup(workspace);
                 }
             } catch (IOException x) {
                 LOGGER.log(Level.FINE, "could not check " + workspace, x);


### PR DESCRIPTION
Not clear if this is a fix for all cases of [JENKINS-31769](https://issues.jenkins-ci.org/browse/JENKINS-31769), but at least one thing I could reproduce. Using a slave

```xml
<?xml version='1.0' encoding='UTF-8'?>
<slave>
  <name>slow</name>
  <description></description>
  <remoteFS>…</remoteFS>
  <numExecutors>5</numExecutors>
  <mode>NORMAL</mode>
  <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
  <launcher class="org.jenkinci.plugins.mock_slave.MockSlaveLauncher" plugin="mock-slave@1.8">
    <latency>10</latency>
    <bandwidth>0</bandwidth>
  </launcher>
  <label></label>
  <nodeProperties/>
  <userId>anonymous</userId>
</slave>
```

and script

```groovy
def go() {
    for (int i = 0; i < 100; i++) {
        echo "iteration #${i}"
        sh "sleep ${new Random().nextInt(5) + 1}"
    }
}
node('slow') {
    def branches = [:]
    for (int i = 0; i < 25; i++) {
        branches["b${i}"] = {go()}
    }
    parallel branches
}
```

I could occasionally reproduce the `InterruptedException` in `FileMonitoringController.cleanup`, leading to an `Execution` with `recurrencePeriod` set to zero. Such a step could not be interrupted normally.

There also seems to be a problem that interrupting the build does not work reliably—the event is only delivered to some branches. Not sure if that is relevant to the hang; will try to fix it if I can.

@reviewbybees