### PR TITLE
Correcting help for the shell step.

### DIFF
--- a/durable-task-step/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStep/help.html
+++ b/durable-task-step/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStep/help.html
@@ -1,10 +1,12 @@
 <div>
     <p>
-    Runs a Bourne shell script on a Unix node. Multiple lines are accepted.
+    Runs a Bourne shell script, typically on a Unix node. Multiple lines are accepted.
+    </p>
+    <p>
     An interpreter selector may be used, for example: <code>#!/usr/bin/perl</code>
     </p>
     <p>
-    And probably <code>set +e</code> and/or <code>set +x</code> to disable the flags
-    that are set by default
+    Otherwise the system default shell will be run, using the <code>-xe</code> flags
+    (you can specify <code>set +e</code> and/or <code>set +x</code> to disable those).
     </p>
 </div>


### PR DESCRIPTION
Amends help in #211 so CC @amuniz. `-xe` are passed only if an explicit interpreter is _not_ defined. [reference](https://github.com/jenkinsci/durable-task-plugin/blob/b27495f9190939590660c29971317ddcd2c774cf/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java#L70-L73)

@reviewbybees