### PR TITLE
[JENKINS-29326] Don't add duplicate BuildData (downstream)

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
@@ -166,9 +166,7 @@ public class GitStepTest {
         assertFalse(iterator.hasNext());
     }
 
-    // This test is currently disabled until the fix for JENKINS-29326 is released
-    // in the git plugin, in 2.4.1 or later.
-    @Ignore
+    @Ignore("This test is currently disabled until the fix for JENKINS-29326 is released in the git plugin 2.4.1 or later.")
     @Issue("JENKINS-29326")
     @Test
     public void identicalGitSCMs() throws Exception {

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.steps.scm;
 
 import hudson.model.Label;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitTagAction;
 import hudson.plugins.git.util.BuildData;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
@@ -187,13 +188,16 @@ public class GitStepTest {
                         "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(1, b.getActions(BuildData.class).size());
-        assertEquals(1, b.getChangeSets().size());
+        assertEquals(1, b.getActions(GitTagAction.class).size());
+        assertEquals(0, b.getChangeSets().size());
 
         otherRepo.write("secondfile", "");
         otherRepo.git("add", "secondfile");
         otherRepo.git("commit", "--message=second");
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertEquals(1, b.getChangeSets().size());
+        assertEquals(1, b2.getActions(BuildData.class).size());
+        assertEquals(1, b2.getActions(GitTagAction.class).size());
+        assertEquals(1, b2.getChangeSets().size());
         assertFalse(b2.getChangeSets().get(0).isEmptySet());
     }
 }

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitStepTest.java
@@ -190,6 +190,7 @@ public class GitStepTest {
         assertEquals(1, b.getActions(BuildData.class).size());
         assertEquals(1, b.getActions(GitTagAction.class).size());
         assertEquals(0, b.getChangeSets().size());
+        assertEquals(1, p.getSCMs().size());
 
         otherRepo.write("secondfile", "");
         otherRepo.git("add", "secondfile");
@@ -199,5 +200,6 @@ public class GitStepTest {
         assertEquals(1, b2.getActions(GitTagAction.class).size());
         assertEquals(1, b2.getChangeSets().size());
         assertFalse(b2.getChangeSets().get(0).isEmptySet());
+        assertEquals(1, p.getSCMs().size());
     }
 }

--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -444,11 +445,11 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         if (b == null) {
             return Collections.emptySet();
         }
-        List<SCM> scms = new LinkedList<SCM>();
+        Map<String,SCM> scms = new LinkedHashMap<String,SCM>();
         for (WorkflowRun.SCMCheckout co : b.checkouts(null)) {
-            scms.add(co.scm);
+            scms.put(co.scm.getKey(), co.scm);
         }
-        return scms;
+        return scms.values();
     }
 
     public @CheckForNull SCM getTypicalSCM() {


### PR DESCRIPTION
Marked as @Ignore until
https://github.com/jenkinsci/git-plugin/pull/372 is merged and
released, at which point we'll need to bump the git plugin version as well.