### PR TITLE
Add EXECUTOR_NUMBER to build env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Only noting significant user changes, not internal code cleanups and minor bug f
 * [JENKINS-26126](https://issues.jenkins-ci.org/browse/JENKINS-26126) (partial): introspect Workflow steps to generate static reference documentation (link from _Snippet Generator_). Planned to be used for IDE auto-completion as well.
 * [JENKINS-31897](https://issues.jenkins-ci.org/browse/JENKINS-31897): parameters with default values may now be omitted from the `parameters` option to the `build` step.
 * [JENKINS-31909](https://issues.jenkins-ci.org/browse/JENKINS-31909): form validation warning about Groovy syntax errors was broken in 1.11.
+* [JENKINS-31391](https://issues.jenkins-ci.org/browse/JENKINS-31391): pass `EXECUTOR_NUMBER` into `node {}`.
 
 ## 1.12 (Dec 14 2015)
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -43,7 +43,7 @@ public class EnvWorkflowTest {
      *
      * @throws Exception
      */
-    @Test public void areAvailable() throws Exception {
+    @Test public void isNodeNameAvailable() throws Exception {
         r.createSlave("node-test", null, null);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
 
@@ -60,5 +60,30 @@ public class EnvWorkflowTest {
             "}\n"
         ));
         r.assertLogContains("My name on a slave is node-test", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
+
+    /**
+     * Verifies if EXECUTOR_NUMBER environment variable is available on a slave node and on master.
+     *
+     * @throws Exception
+     */
+    @Test public void isExecutorNumberAvailable() throws Exception {
+        r.createSlave("node-test", null, null);
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('master') {\n" +
+                        "  echo \"My number on master is ${env.EXECUTOR_NUMBER}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My number on master is 0", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('node-test') {\n" +
+                        "  echo \"My number on a slave is ${env.EXECUTOR_NUMBER}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My number on a slave is 0", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 }

--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/EnvActionImpl/Binder/help.jelly
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/EnvActionImpl/Binder/help.jelly
@@ -34,7 +34,6 @@ node {
         The following variables are currently unavailable inside a workflow script:
     </p>
     <ul>
-        <li><code>EXECUTOR_NUMBER</code></li>
         <li><code>NODE_LABELS</code></li>
         <li><code>WORKSPACE</code></li>
         <!-- TODO when JENKINS-24141 fixed: SCM.all().each { e -> st.include(class:e.clazz, page:"buildEnv", optional:true) } -->

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -422,6 +422,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         } else {
                             env.put("NODE_NAME", label);
                         }
+                        env.put("EXECUTOR_NUMBER", String.valueOf(getExecutor().getNumber()));
 
                         synchronized (runningTasks) {
                             runningTasks.put(cookie, new RunningTask());

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -422,7 +422,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         } else {
                             env.put("NODE_NAME", label);
                         }
-                        env.put("EXECUTOR_NUMBER", String.valueOf(getExecutor().getNumber()));
+                        env.put("EXECUTOR_NUMBER", String.valueOf(exec.getNumber()));
 
                         synchronized (runningTasks) {
                             runningTasks.put(cookie, new RunningTask());


### PR DESCRIPTION
All credit goes to #246, most of this is copied verbatim from that patch.
I basically just corrected the source to actually take the executor number.

I couldn't get the tests to run properly locally, so I am pushing here to get it picked up by CI.