### PR TITLE
[JENKINS-30395] Extend workaround to subclasses of AbstractCpsFlowTest

### DIFF
--- a/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/AbstractCpsFlowTest.java
+++ b/cps/src/test/java/org/jenkinsci/plugins/workflow/cps/AbstractCpsFlowTest.java
@@ -50,7 +50,14 @@ public abstract class AbstractCpsFlowTest {
     public TemporaryFolder tmp = new TemporaryFolder();
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule jenkins = new JenkinsRule() {
+        @Override public void before() throws Throwable {
+            if (Thread.interrupted()) {
+                System.err.println("was interrupted before start");
+            }
+            super.before();
+        }
+    };
 
     /**
      * Currently executing flow.


### PR DESCRIPTION
Follow-up to #277, trying to solve remaining failures like [this](https://jenkins.ci.cloudbees.com/job/plugins/job/workflow-plugin/org.jenkins-ci.plugins.workflow$workflow-aggregator/2040/testReport/junit/org.jenkinsci.plugins.workflow/WorkflowJobNonRestartingTest/sandbox/).

@reviewbybees