### PR TITLE
Escape method name.

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -104,7 +104,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
         final StepDescriptor d = functions.get(name);
         if (d == null) {
-            throw new NoSuchMethodError("No such DSL method " + name + " found among " + functions.keySet());
+            throw new NoSuchMethodError("No such DSL method '" + name + "' found among " + functions.keySet());
         }
 
         final NamedArgsAndClosure ps = parseArgs(d,args);


### PR DESCRIPTION
Confuses me with `No such DSL method step found among [...`