### PR TITLE
Miscellaneous fixes for acceptance test failures

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -69,6 +69,7 @@ public class EnvWorkflowTest {
      * @throws Exception
      */
     @Test public void isExecutorNumberAvailable() throws Exception {
+        r.jenkins.setNumExecutors(1);
         r.createSlave("node-test", null, null);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
 

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/ScalabilityTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/ScalabilityTest.java
@@ -39,7 +39,7 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class ScalabilityTest {
 
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public RestartableJenkinsRule story = JenkinsRuleExt.workAroundJenkins30395Restartable();
 
     @Issue("JENKINS-30055")
     @Test public void manySteps() {

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -4,7 +4,6 @@ import javax.inject.Inject;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.JenkinsRuleExt;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
@@ -51,7 +50,6 @@ public class RestartingLoadStepTest {
 
                 // get the build going
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
-                CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
 
                 // wait until the executor gets assigned and the execution pauses
                 SemaphoreStep.waitForStart("watchA/1", b);
@@ -63,15 +61,11 @@ public class RestartingLoadStepTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
-                CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
 
                 // resume from where it left off
                 SemaphoreStep.success("watchA/1", null);
 
-                // wait until the completion
-                while (b.isBuilding())
-                    e.waitForSuspension();
-
+                story.j.waitForCompletion(b);
                 story.j.assertBuildStatusSuccess(b);
 
                 story.j.assertLogContains("o=42", b);
@@ -101,7 +95,6 @@ public class RestartingLoadStepTest {
 
                 // get the build going
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
-                CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
 
                 // wait until the executor gets assigned and the execution pauses
                 SemaphoreStep.waitForStart("watchB/1", b);
@@ -113,15 +106,11 @@ public class RestartingLoadStepTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
-                CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
 
                 // resume from where it left off
                 SemaphoreStep.success("watchB/1", null);
 
-                // wait until the completion
-                while (b.isBuilding())
-                    e.waitForSuspension();
-
+                story.j.waitForCompletion(b);
                 story.j.assertBuildStatusSuccess(b);
 
                 story.j.assertLogContains("o=42", b);

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/EchoStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/EchoStepTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jenkinsci.plugins.workflow.JenkinsRuleExt;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
@@ -45,7 +46,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class EchoStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public JenkinsRule r = JenkinsRuleExt.workAroundJenkins30395();
 
     @Test public void smokes() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -864,7 +864,7 @@ public class CpsFlowExecution extends FlowExecution {
                 CpsFlowExecution exec = (CpsFlowExecution) execution;
                 // Like waitForSuspension but with a timeout:
                 if (exec.programPromise != null) {
-                    exec.programPromise.get().scheduleRun().get(1, TimeUnit.MINUTES);
+                    exec.programPromise.get(1, TimeUnit.MINUTES).scheduleRun().get(1, TimeUnit.MINUTES);
                 }
             }
         }

--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputAction.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputAction.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.workflow.support.steps.input;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -21,7 +23,8 @@ public class InputAction implements RunAction2 {
     private static final Logger LOGGER = Logger.getLogger(InputAction.class.getName());
 
     private transient List<InputStepExecution> executions = new ArrayList<InputStepExecution>();
-    private List<String> ids = new ArrayList<String>();
+    @SuppressFBWarnings(value="IS2_INCONSISTENT_SYNC", justification="CopyOnWriteArrayList")
+    private List<String> ids = new CopyOnWriteArrayList<String>();
 
     private transient Run<?,?> run;
 
@@ -89,16 +92,20 @@ public class InputAction implements RunAction2 {
 
     @Override
     public String getIconFileName() {
-        loadExecutions();
-        if (executions.isEmpty())    return null;
-        else                    return "help.png";
+        if (ids == null || ids.isEmpty()) {
+            return null;
+        } else {
+            return "help.png";
+        }
     }
 
     @Override
     public String getDisplayName() {
-        loadExecutions();
-        if (executions.isEmpty())    return null;
-        else                    return "Paused for Input";
+        if (ids == null || ids.isEmpty()) {
+            return null;
+        } else {
+            return "Paused for Input";
+        }
     }
 
     @Override

--- a/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution/PlaceholderTask/PlaceholderExecutable/executorCell.jelly
+++ b/support/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution/PlaceholderTask/PlaceholderExecutable/executorCell.jelly
@@ -27,7 +27,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:l="/lib/layout">
     <td class="pane">
         <div style="white-space: normal">
-            <j:set var="r" value="${it.parent.run()}"/>
+            <j:set var="r" value="${it.parent.runForDisplay()}"/>
             <j:set var="rAuth" value="${r != null and h.hasPermission(r.parent, r.parent.READ) ? r : null}"/>
             <j:choose>
                 <j:when test="${rAuth != null}">


### PR DESCRIPTION
Partly follows up #301, plus some other fixes inspired by looking at a thread dump from a `linearFlow` failure. Per-commit messages have detailed justifications.

Now subsumes #310.

@reviewbybees