### PR TITLE
Minor changes to console logs forgotten in JENKINS-30088 fix

### DIFF
--- a/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
+++ b/api/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java
@@ -176,7 +176,7 @@ public abstract class FlowNode extends Actionable implements Saveable {
         } else {
             LabelAction a = getAction(LabelAction.class);
             if (a != null) {
-                return functionName + ": " + a.getDisplayName();
+                return functionName + " (" + a.getDisplayName() + ")";
             } else {
                 return functionName;
             }

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStepExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStepExecution.java
@@ -36,7 +36,7 @@ public class LoadStepExecution extends AbstractStepExecutionImpl {
 
         Script script = shell.parse(cwd.child(step.getPath()).readToString());
 
-        node.addAction(new LabelAction("Loaded script: "+step.getPath()));
+        node.addAction(new LabelAction(step.getPath()));
 
         // execute body as another thread that shares the same head as this thread
         // as the body can pause.

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
@@ -80,7 +80,7 @@ class ParallelStepExecution extends StepExecution {
 
         @Override
         public String getDisplayName() {
-            return "Parallel branch: "+branchName;
+            return "Branch: " + branchName;
         }
 
         @Nonnull


### PR DESCRIPTION
[JENKINS-30088](https://issues.jenkins-ci.org/browse/JENKINS-30088)

Before:

```
[Pipeline] node {
[Pipeline] Execute sub-workflows in parallel : Start
[Pipeline] [firstBranch] parallel {: Parallel branch: firstBranch
[Pipeline] [secondBranch] parallel {: Parallel branch: secondBranch
[Pipeline] [firstBranch] writeFile
[Pipeline] [firstBranch] stash
```

After:

```
[Pipeline] node {
[Pipeline] Execute sub-workflows in parallel : Start
[Pipeline] [firstBranch] parallel { (Branch: firstBranch)
[Pipeline] [secondBranch] parallel { (Branch: secondBranch)
[Pipeline] [firstBranch] writeFile
[Pipeline] [firstBranch] stash
```

@reviewbybees 