### PR TITLE
[FIXED JENKINS-32547] Make `durable-task-step` play nicely with WinRM connections

### DIFF
--- a/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/durable-task-step/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -167,7 +167,7 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
             if (workspace == null) {
                 return; // slave not yet ready, wait for another day
             }
-            // Do not allow this to take more than 3s for any given task:
+            // Do not allow this to take more than 10s for any given task:
             final AtomicReference<Thread> t = new AtomicReference<Thread>(Thread.currentThread());
             Timer.get().schedule(new Runnable() {
                 @Override public void run() {
@@ -176,7 +176,7 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
                         _t.interrupt();
                     }
                 }
-            }, 3, TimeUnit.SECONDS);
+            }, 10, TimeUnit.SECONDS);
             try {
                 if (controller.writeLog(workspace, listener.getLogger())) {
                     getContext().saveState();


### PR DESCRIPTION
[JENKINS-32547](https://issues.jenkins-ci.org/browse/JENKINS-32547)

WinRM is slow. Like, really, __really__ slow. So slow, that streaming
back the results of a `DurableTaskStep` can easily take more than
the previously set timeout of 3 seconds. This would cause even
super-simple builds steps like `bat 'echo TEST'` to run for very
long times (in some cases more than 20 minutes).

Bumping the internal timeout of a `DurableTaskStep` to 10 seconds seems
to fix any issues with slaves connected over WinRM, and I've not seen
a single `InterruptedException` show up in the log files.