### PR TITLE
Fixed onclick handler

### DIFF
--- a/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/POSTHyperlinkNote.java
+++ b/support/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/POSTHyperlinkNote.java
@@ -80,8 +80,7 @@ public final class POSTHyperlinkNote extends HyperlinkNote {
 
     @Override protected String extraAttributes() {
         // TODO perhaps add hoverNotification
-        // TODO do we need to add a crumb if security is enabled?
-        return " onclick=\"new Ajax.Request('" + url + "'); false\"";
+        return " onclick=\"new Ajax.Request('" + url + "'); return false\"";
     }
 
     // TODO why does there need to be a descriptor at all?


### PR DESCRIPTION
Fixes a trivial but longstanding annoyance: that the console log scrolls back up to the top of the screen when you click on _Proceed_ from an `input` step (for example).

The comment about `crumb` was deleted because I confirmed that it works, due to [this hack](https://github.com/jenkinsci/jenkins/blob/1f89b5a9096f8d4946c1797e79ca5e2f494175ee/war/src/main/webapp/scripts/prototype.js#L1535-L1541).

@reviewbybees