### PR TITLE
Remove “formerly known” text

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -32,7 +32,7 @@
     </parent>
     <artifactId>workflow-aggregator</artifactId>
     <packaging>hpi</packaging>
-    <name>Pipeline (formerly known as Workflow)</name>
+    <name>Pipeline</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin</url>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Reverts this part of #296 now that 1.13 has been released.

@reviewbybees esp. @recena