### PR TITLE
Build Monitor supports Jenkins Workflow jobs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -116,6 +116,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [ ] `ownership` : [JENKINS-32353](https://issues.jenkins-ci.org/browse/JENKINS-32353)
 - [ ] `job-restrictions`: [JENKINS-32355](https://issues.jenkins-ci.org/browse/JENKINS-32355)
 - [X] `buildtriggerbadge`: supported as of 2.2
+- [X] `build-monitor`: supported as of 1.6+build.159 
 - [X] `radiatorview`: supported as of 1.25
 - [ ] `chucknorris`: [JENKINS-32594](https://issues.jenkins-ci.org/browse/JENKINS-32594)
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -116,7 +116,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [ ] `ownership` : [JENKINS-32353](https://issues.jenkins-ci.org/browse/JENKINS-32353)
 - [ ] `job-restrictions`: [JENKINS-32355](https://issues.jenkins-ci.org/browse/JENKINS-32355)
 - [X] `buildtriggerbadge`: supported as of 2.2
-- [X] `build-monitor`: supported as of 1.6+build.159 
+- [X] `build-monitor-plugin`: supported as of 1.6+build.159 
 - [X] `radiatorview`: supported as of 1.25
 - [ ] `chucknorris`: [JENKINS-32594](https://issues.jenkins-ci.org/browse/JENKINS-32594)
 


### PR DESCRIPTION
Build Monitor can display Jenkins Workflow jobs since version 1.6+build.159 