### PR TITLE
Fix instructions to omit /jenkins path

### DIFF
--- a/cps-global-lib/README.md
+++ b/cps-global-lib/README.md
@@ -41,7 +41,7 @@ This directory is managed by Git, and you'll deploy new changes through `git pus
 The repository is exposed in two endpoints:
 
  * `ssh://USERNAME@server:PORT/workflowLibs.git` through [Jenkins SSH](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+SSH)
- * `http://server/jenkins/workflowLibs.git` (when your Jenkins is `http://server/jenkins/`). As noted in [JENKINS-26537](https://issues.jenkins-ci.org/browse/JENKINS-26537), this mode will not currently work in an authenticated Jenkins instance.
+ * `http://LOCATION/workflowLibs.git` (when your Jenkins app is located on the url `http://LOCATION/`). As noted in [JENKINS-26537](https://issues.jenkins-ci.org/browse/JENKINS-26537), this mode will not currently work in an authenticated Jenkins instance. 
 
 Having the shared library script in Git allows you to track changes, perform
 tested deployments, and reuse the same scripts across a large number of instances.


### PR DESCRIPTION
People will mostly be using global lib from a non `mvn hpi:run` debug mode and including http://server/jenkins was thus confusing.

@reviewbybees 