### PR TITLE
logPrefixCache was not intended to be serialized

### DIFF
--- a/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/job/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -398,7 +398,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @GuardedBy("completed")
-    private LoadingCache<FlowNode,Optional<String>> logPrefixCache;
+    private transient LoadingCache<FlowNode,Optional<String>> logPrefixCache;
     private @CheckForNull String getLogPrefix(FlowNode node) {
         synchronized (completed) {
             if (logPrefixCache == null) {


### PR DESCRIPTION
Mistake in #213 which leads to junk in `build.xml` in 1.13.

@reviewbybees