### PR TITLE
Simple form of sleep step would fail in sandbox

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/SleepStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/SleepStepTest.java
@@ -50,7 +50,7 @@ public class SleepStepTest {
         r.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("semaphore 'start'; sleep 10"));
+                p.setDefinition(new CpsFlowDefinition("semaphore 'start'; sleep 10", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("start/1", b);
                 SemaphoreStep.success("start/1", null);

--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -39,6 +39,7 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.DefaultGroovyStaticMethods;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -198,6 +199,7 @@ public abstract class CpsScript extends SerializableScript {
      *
      * @see CpsClosure2#sleep(long)
      */
+    @Whitelisted
     public Object sleep(long arg) {
         return invokeMethod("sleep", arg);
     }


### PR DESCRIPTION
`CpsClosure2.sleep` was already `@Whitelisted`, but this one (used _outside_ blocks/closures) was forgotten.

@reviewbybees