### PR TITLE
[JENKINS-32925] Add tracking to prevent stack overflows

### DIFF
--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
@@ -301,6 +301,9 @@ public class DescribableHelper {
 
         static ParameterType of(Type type, Stack<String> tracker) {
             try {
+                if(tracker == null){ //in case called externally
+                    tracker = new Stack<String>();
+                }
                 if (type instanceof Class) {
                     Class<?> c = (Class<?>) type;
                     if (c == String.class || Primitives.unwrap(c).isPrimitive()) {

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
@@ -337,20 +337,16 @@ public class DescribableHelper {
                                 subtypesBySimpleName.put(simpleName, bySimpleName = new ArrayList<Class<?>>());
                             }
                             bySimpleName.add(subtype);
-                            LOG.log(Level.INFO, "Value of subtype: " + simpleName);
                         }
                         Map<String,Schema> types = new TreeMap<String,Schema>();
                         for (Map.Entry<String,List<Class<?>>> entry : subtypesBySimpleName.entrySet()) {
                             if (entry.getValue().size() == 1) { // normal case: unambiguous via simple name
                                 try {
                                     String key = entry.getKey();
-                                    LOG.log(Level.INFO, "entry value size=1 key: "+key+" stack size: "+tracker.size());
                                     if(tracker.search(key) < 0) {
                                         tracker.push(key);
                                         types.put(key, schemaFor(entry.getValue().get(0), tracker));
                                         tracker.pop();
-                                    } else {
-                                        LOG.log(Level.INFO, "I safelly triggered the stack!");
                                     }
                                 } catch (Exception x) {
                                     LOG.log(Level.FINE, "skipping subtype", x);
@@ -359,14 +355,11 @@ public class DescribableHelper {
                                 for (Class<?> subtype : entry.getValue()) {
                                     try {
                                         String name = subtype.getName();
-                                        LOG.log(Level.INFO, "entry value size!=1 name: "+name+" stack size: "+tracker.size());
                                         if(tracker.search(name) < 0) {
                                             tracker.push(name);
                                             types.put(name, schemaFor(subtype, tracker));
                                             tracker.pop();
-                                        } else {
-                                        LOG.log(Level.INFO, "I safelly triggered the stack!");
-                                    }
+                                        }
                                     } catch (Exception x) {
                                         LOG.log(Level.FINE, "skipping subtype", x);
                                     }

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -147,6 +148,10 @@ public class DescribableHelper {
     public static Schema schemaFor(Class<?> clazz) {
         return new Schema(clazz);
     }
+    
+    public static Schema schemaFor(Class<?> clazz, Stack<String> tracker) {
+        return new Schema(clazz, tracker);
+    }
 
     /**
      * Definition of how a particular class may be configured.
@@ -158,20 +163,27 @@ public class DescribableHelper {
         private final List<String> mandatoryParameters;
 
         Schema(Class<?> clazz) {
+            this(clazz, null);
+        }
+
+        Schema(Class<?> clazz, Stack<String> tracker) {
             this.type = clazz;
+            if(tracker == null){
+                tracker = new Stack<String>();
+            }
             mandatoryParameters = new ArrayList<String>();
             parameters = new TreeMap<String,ParameterType>();
             String[] names = loadConstructorParamNames(clazz);
             Type[] types = findConstructor(clazz, names.length).getGenericParameterTypes();
             for (int i = 0; i < names.length; i++) {
                 mandatoryParameters.add(names[i]);
-                parameters.put(names[i], ParameterType.of(types[i]));
+                parameters.put(names[i], ParameterType.of(types[i], tracker));
             }
             for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
                 for (Field f : c.getDeclaredFields()) {
                     if (f.isAnnotationPresent(DataBoundSetter.class)) {
                         f.setAccessible(true);
-                        parameters.put(f.getName(), ParameterType.of(f.getGenericType()));
+                        parameters.put(f.getName(), ParameterType.of(f.getGenericType(), tracker));
                     }
                 }
                 for (Method m : c.getDeclaredMethods()) {
@@ -181,7 +193,7 @@ public class DescribableHelper {
                             throw new IllegalStateException(m + " cannot be a @DataBoundSetter");
                         }
                         m.setAccessible(true);
-                        parameters.put(Introspector.decapitalize(m.getName().substring(3)), ParameterType.of(m.getGenericParameterTypes()[0]));
+                        parameters.put(Introspector.decapitalize(m.getName().substring(3)), ParameterType.of(m.getGenericParameterTypes()[0], tracker));
                     }
                 }
             }
@@ -282,8 +294,12 @@ public class DescribableHelper {
         ParameterType(Type actualType) {
             this.actualType = actualType;
         }
+        
+        static ParameterType of(Type type){
+            return of(type, new Stack<String>());
+        }
 
-        static ParameterType of(Type type) {
+        static ParameterType of(Type type, Stack<String> tracker) {
             try {
                 if (type instanceof Class) {
                     Class<?> c = (Class<?>) type;
@@ -318,19 +334,36 @@ public class DescribableHelper {
                                 subtypesBySimpleName.put(simpleName, bySimpleName = new ArrayList<Class<?>>());
                             }
                             bySimpleName.add(subtype);
+                            LOG.log(Level.INFO, "Value of subtype: " + simpleName);
                         }
                         Map<String,Schema> types = new TreeMap<String,Schema>();
                         for (Map.Entry<String,List<Class<?>>> entry : subtypesBySimpleName.entrySet()) {
                             if (entry.getValue().size() == 1) { // normal case: unambiguous via simple name
                                 try {
-                                    types.put(entry.getKey(), schemaFor(entry.getValue().get(0)));
+                                    String key = entry.getKey();
+                                    LOG.log(Level.INFO, "entry value size=1 key: "+key+" stack size: "+tracker.size());
+                                    if(tracker.search(key) < 0) {
+                                        tracker.push(key);
+                                        types.put(key, schemaFor(entry.getValue().get(0), tracker));
+                                        tracker.pop();
+                                    } else {
+                                        LOG.log(Level.INFO, "I safelly triggered the stack!");
+                                    }
                                 } catch (Exception x) {
                                     LOG.log(Level.FINE, "skipping subtype", x);
                                 }
                             } else { // have to diambiguate via FQN
                                 for (Class<?> subtype : entry.getValue()) {
                                     try {
-                                        types.put(subtype.getName(), schemaFor(subtype));
+                                        String name = subtype.getName();
+                                        LOG.log(Level.INFO, "entry value size!=1 name: "+name+" stack size: "+tracker.size());
+                                        if(tracker.search(name) < 0) {
+                                            tracker.push(name);
+                                            types.put(name, schemaFor(subtype, tracker));
+                                            tracker.pop();
+                                        } else {
+                                        LOG.log(Level.INFO, "I safelly triggered the stack!");
+                                    }
                                     } catch (Exception x) {
                                         LOG.log(Level.FINE, "skipping subtype", x);
                                     }

--- a/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
+++ b/step-api/src/main/java/org/jenkinsci/plugins/workflow/structs/DescribableHelper.java
@@ -149,7 +149,7 @@ public class DescribableHelper {
         return new Schema(clazz);
     }
     
-    public static Schema schemaFor(Class<?> clazz, Stack<String> tracker) {
+    private static Schema schemaFor(Class<?> clazz, Stack<String> tracker) {
         return new Schema(clazz, tracker);
     }
 
@@ -163,14 +163,14 @@ public class DescribableHelper {
         private final List<String> mandatoryParameters;
 
         Schema(Class<?> clazz) {
-            this(clazz, null);
+            this(clazz, new Stack<String>());
         }
 
-        Schema(Class<?> clazz, Stack<String> tracker) {
+        Schema(Class<?> clazz, @Nonnull Stack<String> tracker) {
             this.type = clazz;
-            if(tracker == null){
+            /*if(tracker == null){
                 tracker = new Stack<String>();
-            }
+            }*/
             mandatoryParameters = new ArrayList<String>();
             parameters = new TreeMap<String,ParameterType>();
             String[] names = loadConstructorParamNames(clazz);
@@ -299,11 +299,8 @@ public class DescribableHelper {
             return of(type, new Stack<String>());
         }
 
-        static ParameterType of(Type type, Stack<String> tracker) {
+        private static ParameterType of(Type type, @Nonnull Stack<String> tracker) {
             try {
-                if(tracker == null){ //in case called externally
-                    tracker = new Stack<String>();
-                }
                 if (type instanceof Class) {
                     Class<?> c = (Class<?>) type;
                     if (c == String.class || Primitives.unwrap(c).isPrimitive()) {

--- a/step-api/src/test/java/org/jenkinsci/plugins/workflow/structs/DescribableHelperTest.java
+++ b/step-api/src/test/java/org/jenkinsci/plugins/workflow/structs/DescribableHelperTest.java
@@ -154,7 +154,7 @@ public class DescribableHelperTest {
     }
 
     @Test public void findSubtypes() throws Exception {
-        assertEquals(new HashSet<Class<?>>(Arrays.asList(Impl1.class, Impl2.class)), DescribableHelper.findSubtypes(Base.class));
+        assertEquals(new HashSet<Class<?>>(Arrays.asList(Impl1.class, Impl2.class, Impl3.class)), DescribableHelper.findSubtypes(Base.class));
         assertEquals(Collections.singleton(Impl1.class), DescribableHelper.findSubtypes(Marker.class));
     }
 
@@ -172,7 +172,7 @@ public class DescribableHelperTest {
         roundTrip(UsesBase.class, map("base", map(CLAZZ, "Impl1", "text", "hello")));
         roundTrip(UsesBase.class, map("base", map(CLAZZ, "Impl2", "flag", true)));
         roundTrip(UsesImpl2.class, map("impl2", map()));
-        schema(UsesBase.class, "(base: Base{Impl1=(text: String), Impl2=([flag: boolean])})");
+        schema(UsesBase.class, "(base: Base{Impl1=(text: String), Impl2=([flag: boolean]), Impl3=(base: Base{Impl1=(text: String), Impl2=([flag: boolean])})})");
         schema(UsesImpl2.class, "(impl2: Impl2([flag: boolean]))");
         schema(UsesUnimplementedExtensionPoint.class, "(delegate: UnimplementedExtensionPoint{})");
         schema(UsesSomeImplsBroken.class, "(delegate: SomeImplsBroken{FineImpl=()})");
@@ -235,6 +235,25 @@ public class DescribableHelperTest {
         @Extension public static final class DescriptorImpl extends Descriptor<Base> {
             @Override public String getDisplayName() {
                 return "Impl2";
+            }
+        }
+    }
+    
+    //use to trigger recursion subcases
+    public static final class Impl3 extends Base {
+        private final Base base;
+        @DataBoundConstructor public Impl3(Base base) {
+            this.base = base;
+        }
+        public Base getBase() {
+            return base;
+        }
+        @Override public String toString() {
+            return "Impl3[" + base.toString() + "]";
+        }
+        @Extension public static final class DescriptorImpl extends Descriptor<Base> {
+            @Override public String getDisplayName() {
+                return "Impl3";
             }
         }
     }
@@ -389,7 +408,7 @@ public class DescribableHelperTest {
 
     @Test public void structArrayHetero() throws Exception {
         roundTrip(UsesStructArrayHetero.class, map("bases", Arrays.asList(map(CLAZZ, "Impl1", "text", "hello"), map(CLAZZ, "Impl2", "flag", true))), "UsesStructArrayHetero[Impl1[hello], Impl2[true]]");
-        schema(UsesStructArrayHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean])}[])");
+        schema(UsesStructArrayHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean]), Impl3=(base: Base{Impl1=(text: String), Impl2=([flag: boolean])})}[])");
     }
 
     public static final class UsesStructArrayHetero {
@@ -407,7 +426,7 @@ public class DescribableHelperTest {
 
     @Test public void structListHetero() throws Exception {
         roundTrip(UsesStructListHetero.class, map("bases", Arrays.asList(map(CLAZZ, "Impl1", "text", "hello"), map(CLAZZ, "Impl2", "flag", true))), "UsesStructListHetero[Impl1[hello], Impl2[true]]");
-        schema(UsesStructListHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean])}[])");
+        schema(UsesStructListHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean]), Impl3=(base: Base{Impl1=(text: String), Impl2=([flag: boolean])})}[])");
     }
 
     public static final class UsesStructListHetero {
@@ -425,7 +444,7 @@ public class DescribableHelperTest {
 
     @Test public void structCollectionHetero() throws Exception {
         roundTrip(UsesStructCollectionHetero.class, map("bases", Arrays.asList(map(CLAZZ, "Impl1", "text", "hello"), map(CLAZZ, "Impl2", "flag", true))), "UsesStructCollectionHetero[Impl1[hello], Impl2[true]]");
-        schema(UsesStructCollectionHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean])}[])");
+        schema(UsesStructCollectionHetero.class, "(bases: Base{Impl1=(text: String), Impl2=([flag: boolean]), Impl3=(base: Base{Impl1=(text: String), Impl2=([flag: boolean])})}[])");
     }
 
     public static final class UsesStructCollectionHetero {


### PR DESCRIPTION
[JENKINS-32925](https://issues.jenkins-ci.org/browse/JENKINS-32925)

To prevent stack overflows, especially in the Multiple SCMs case, track the subtypes to make sure the type isn't trying to discover itself.  When that case is detected, don't log, and return back up the stack.  This will only prevent duplication vertically, not horizontally.

@reviewbybees  esp @jglick & @abayer 