### PR TITLE
Use repackaged jQuery HPI

### DIFF
--- a/cps/pom.xml
+++ b/cps/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>jquery-detached</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>


### PR DESCRIPTION
The jQuery plugin was bloated due to a bad assembly. See [JENKINS-33245](https://issues.jenkins-ci.org/browse/JENKINS-33245).

@jenkinsci/code-reviewers @reviewbybees 