### PR TITLE
Added aws-lambda-plugin to compatibility.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -62,6 +62,9 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [ ] `BapSshPublisher` (`publish-over-ssh`): [JENKINS-27963](https://issues.jenkins-ci.org/browse/JENKINS-27963)
 - [X] `PerfSigRecorder` and 5 more (`performance-signature-dynatrace`): supported as of 2.0
 - [ ] `StashNotifier` (`stashNotifier`): [issue 92](https://github.com/jenkinsci/stashnotifier-plugin/issues/92)
+- [X] `LambdaUploadBuildStep` (`aws-lambda-plugin`): [JENKINS-33198](https://issues.jenkins-ci.org/browse/JENKINS-33198) as of 0.5.0
+- [X] `LambdaInvokeBuildStep` (`aws-lambda-plugin`): [JENKINS-33198](https://issues.jenkins-ci.org/browse/JENKINS-33198) as of 0.5.0
+- [X] `LambdaEventSourceBuildStep` (`aws-lambda-plugin`): [JENKINS-33198](https://issues.jenkins-ci.org/browse/JENKINS-33198) as of 0.5.0
 
 ## Build wrappers
 


### PR DESCRIPTION
Since release 0.5.0 of aws-lambda-plugin compatibility has been added for Pipeline.