### PR TITLE
Bump durable task plugin, specifically because of JENKINS-27152

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>durable-task</artifactId>
-                <version>1.5</version>
+                <version>1.8</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This will fix some counterintuitive hangs due to the control files being inadvertantly removed (also downstream, it will be important for the docker pipeline plugin to take up after the next pipeline release). 