### PR TITLE
Switch baseline to 1.642.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
       <tag>HEAD</tag>
   </scm>
     <properties>
-        <jenkins.version>1.642.1</jenkins.version>
+        <jenkins.version>1.642.3</jenkins.version>
         <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
     </properties>
     <modules>


### PR DESCRIPTION
Pick up yesterday’s LTS release, so that we no longer suffer from the bug fixed in https://github.com/jenkinsci/jenkins/pull/1989, which gravely affects Pipeline build resumption.

Still waiting for `jenkins:1.642.3` to appear in Docker Hub.

@reviewbybees